### PR TITLE
HOTT-1304 News page

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,7 +1,7 @@
 # https://gds-way.cloudapps.digital/manuals/programming-languages/editorconfig
 root = true
 
-[*.{css,erb,js,json,rb,scss,sh,yml,yaml}]
+[*.{builder,css,erb,js,json,rb,scss,sh,yml,yaml}]
 indent_size = 2
 indent_style = space
 charset = utf-8

--- a/Gemfile
+++ b/Gemfile
@@ -5,3 +5,4 @@ ruby File.read('.ruby-version')
 gem 'govuk_tech_docs'
 gem 'middleman-gh-pages', '~> 0.3.1'
 gem 'openapi3_parser'
+gem 'builder'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,6 +12,7 @@ GEM
     autoprefixer-rails (10.4.2.0)
       execjs (~> 2)
     backports (3.23.0)
+    builder (3.2.4)
     chronic (0.10.2)
     chunky_png (1.4.0)
     coffee-script (2.4.1)
@@ -178,6 +179,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  builder
   govuk_tech_docs
   middleman-gh-pages (~> 0.3.1)
   openapi3_parser

--- a/NEWS.yml
+++ b/NEWS.yml
@@ -1,12 +1,12 @@
 - date: 2021-12-20
-  title: Added Rules of Origin API
+  title: Addition of "Rules of Origin" API
   content: |
-    Added a Rules of Origin api for rules relating to importing a commodity from
-    a particular country. This covers
+    Addition of "Rules of Origin" API to illustrate the rules of origin
+    applicable to the import of goods under preferential tariff regimes.
+    This covers:
 
-    * applicable schemes
-    * relevant rules within those schemes
-    * necessary proofs of origin
-    * any relevant links
+    * product-specific rules applicable to each rules of origin scheme
+    * proofs of origin
+    * any relevant links and background information on the trading relationship
 
-    [More info](/reference.html#rules-of-origin)
+    [Rules of Origin API Documentation](/reference.html#rules-of-origin)

--- a/NEWS.yml
+++ b/NEWS.yml
@@ -1,0 +1,1 @@
+data/news.yml

--- a/NEWS.yml
+++ b/NEWS.yml
@@ -1,1 +1,12 @@
-data/news.yml
+- date: 2021-12-20
+  title: Added Rules of Origin API
+  content: |
+    Added a Rules of Origin api for rules relating to importing a commodity from
+    a particular country. This covers
+
+    * applicable schemes
+    * relevant rules within those schemes
+    * necessary proofs of origin
+    * any relevant links
+
+    [More info](/reference.html#rules-of-origin)

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ To update the Trade Tariff API documentation, you may follow this general workfl
     ```
   - manually (re)load [http://localhost:4567](http://localhost:4567) in a browser when the Middleman server (re)starts
 
+- It is also useful to add an entry in the `NEWS.yml` file, this information will be published on the Latest News page for users viewing these docs. It will also be added to the `/feed.xml` atom feed for anyone subscribing for updates.
+
 ### Support for multiple API versions
 
 As we release new versions of the API, we will continue to support older versions (until they're deprecated). Therefore, we should continue to publish that version's API reference and the corresponding `openapi.yaml` file.
@@ -158,6 +160,18 @@ make serve
 ```
 
 You should now be able to view a live preview at http://localhost:4567.
+
+## Publishing documentation
+
+### Development
+
+Any changes pushed to GitHub on a branch (eg, a Pull Request) will be deployed 
+automatically to the [Development URL](https://tariff-api-dev.london.cloudapps.digital)
+
+### Production
+
+Any changes to `main` on GitHub will be deployed automatically to our published docs 
+at [api.trade-tariff.service.gov.uk](https://api.trade-tariff.service.gov.uk) 
 
 ## License
 

--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -11,6 +11,7 @@ service_link: /
 header_links:
   About: /
   Getting Started: /getting-started.html
+  News: /news.html
   API Docs: /reference.html
 
 # Tracking ID from Google Analytics (e.g. UA-XXXX-Y)

--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -11,7 +11,7 @@ service_link: /
 header_links:
   About: /
   Getting Started: /getting-started.html
-  News: /news.html
+  Latest News: /news.html
   API Docs: /reference.html
 
 # Tracking ID from Google Analytics (e.g. UA-XXXX-Y)

--- a/data/news.yml
+++ b/data/news.yml
@@ -1,12 +1,1 @@
-- date: 2021-12-20
-  title: Added Rules of Origin API
-  content: |
-    Added a Rules of Origin api for rules relating to importing a commodity from
-    a particular country. This covers
-
-    * applicable schemes
-    * relevant rules within those schemes
-    * necessary proofs of origin
-    * any relevant links
-
-    [More info](/reference.html#rules-of-origin)
+../NEWS.yml

--- a/data/news.yml
+++ b/data/news.yml
@@ -1,0 +1,12 @@
+- date: 2021-12-20
+  title: Added Rules of Origin API
+  content: |
+    Added a Rules of Origin api for rules relating to importing a commodity from
+    a particular country. This covers
+
+    * applicable schemes
+    * relevant rules within those schemes
+    * necessary proofs of origin
+    * any relevant links
+
+    [More info](/reference.html#rules-of-origin)

--- a/source/feed.xml.builder
+++ b/source/feed.xml.builder
@@ -14,7 +14,7 @@ xml.feed "xmlns" => "http://www.w3.org/2005/Atom" do
   xml.subtitle "API News"
   xml.updated data.news.map(&:date).max.iso8601 unless data.news.empty?
 
-  data.news.each do |news_item|
+  data.news.sort_by(&:date).each do |news_item|
     xml.entry do
       xml.id "tag:#{site_domain},2005:News/#{news_item.date.strftime('%Y-%m-%d')}"
       xml.link "rel" => "alternate", "href" => URI.join(site_url, '/news.html')

--- a/source/feed.xml.builder
+++ b/source/feed.xml.builder
@@ -3,7 +3,7 @@ xml.feed "xmlns" => "http://www.w3.org/2005/Atom" do
   site_domain = "api.trade-tariff.service.gov.uk"
   site_url = "https://#{site_domain}/"
 
-  xml.id "tag:site_domain,2005:/News"
+  xml.id "tag:#{site_domain},2005:/News"
   xml.link 'href' => URI.join(site_url, '/news.html'),
            'rel' => 'alternate',
            'type' => 'text/html'
@@ -12,7 +12,7 @@ xml.feed "xmlns" => "http://www.w3.org/2005/Atom" do
            'type' => 'application/atom+xml'
   xml.title "Online Trade Tariff API"
   xml.subtitle "API News"
-  xml.updated data.news.map(&:date).max.iso8601 unless data.news.empty?
+  xml.updated data.news.map(&:date).max.to_time.iso8601 unless data.news.empty?
 
   data.news.sort_by(&:date).each do |news_item|
     xml.entry do
@@ -20,8 +20,11 @@ xml.feed "xmlns" => "http://www.w3.org/2005/Atom" do
       xml.link "rel" => "alternate", "href" => URI.join(site_url, '/news.html')
       xml.title news_item.title
       xml.content news_item.content
-      xml.published news_item.date.iso8601
-      xml.updated news_item.date.iso8601
+      xml.published news_item.date.to_time.iso8601
+      xml.updated news_item.date.to_time.iso8601
+      xml.author do
+        xml.name "Online Trade Tariff"
+      end
     end
   end
 end

--- a/source/feed.xml.builder
+++ b/source/feed.xml.builder
@@ -1,0 +1,27 @@
+xml.instruct!
+xml.feed "xmlns" => "http://www.w3.org/2005/Atom" do
+  site_domain = "api.trade-tariff.service.gov.uk"
+  site_url = "https://#{site_domain}/"
+
+  xml.id "tag:site_domain,2005:/News"
+  xml.link 'href' => URI.join(site_url, '/news.html'),
+           'rel' => 'alternate',
+           'type' => 'text/html'
+  xml.link 'href' => URI.join(site_url, '/feed.xml'),
+           'rel' => 'self',
+           'type' => 'application/atom+xml'
+  xml.title "Online Trade Tariff API"
+  xml.subtitle "API News"
+  xml.updated data.news.map(&:date).max.iso8601 unless data.news.empty?
+
+  data.news.each do |news_item|
+    xml.entry do
+      xml.id "tag:#{site_domain},2005:News/#{news_item.date.strftime('%Y-%m-%d')}"
+      xml.link "rel" => "alternate", "href" => URI.join(site_url, '/news.html')
+      xml.title news_item.title
+      xml.content news_item.content
+      xml.published news_item.date.iso8601
+      xml.updated news_item.date.iso8601
+    end
+  end
+end

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -1,6 +1,9 @@
 ---
 title: Trade Tariff API - GOV.UK
 ---
+<% content_for :head do %>
+  <link href="/feed.xml" type="application/atom+xml" rel="alternate" title="Latest News Atom feed" />
+<% end %>
 
 # GOV.UK Trade Tariff API
 

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -61,6 +61,12 @@ Usage of GOV.UK Trade Tariff API does not require authentication.
 The GOV.UK Trade Tariff is updated on a daily basis, however to reduce the number of API calls please consider caching 
 requests for 24 hours.
 
+## API updates
+
+Changes to the API are documented on the [Latest News](/news.html) page
+
+They are also available as a feed to subscribe to at the [API News feed](/feed.xml)
+
 ## Security and compliance
 
 ### Reporting vulnerabilities

--- a/source/news.html.md.erb
+++ b/source/news.html.md.erb
@@ -1,0 +1,13 @@
+---
+title: News
+---
+# News
+
+Recent changes to the Trade Tariff API
+
+<% data.news.each.with_index do |news_item, index| %>
+<%= '---' if index > 0 %>
+## <span class="govuk-caption-l"><%= news_item.date.strftime('%-d %B %Y') %></span> <span class="govuk-visually-hidden">-</span> <%= news_item.title %>
+<%= news_item.content %>
+<% end %>
+

--- a/source/news.html.md.erb
+++ b/source/news.html.md.erb
@@ -11,6 +11,8 @@ Changes to the Trade Tariff API are listed below.
 
 These changes can be subscribed to at the [Atom (RSS) feed](/feed.xml)
 
+_All changes apply to the v2 APIs. The v1 API will not be updated from this point onwards._
+
 <% data.news.each.with_index do |news_item, index| %>
 <%= '---' if index > 0 %>
 ## <span class="govuk-caption-l"><%= news_item.date.strftime('%-d %B %Y') %></span> <span class="govuk-visually-hidden">-</span> <%= news_item.title %>

--- a/source/news.html.md.erb
+++ b/source/news.html.md.erb
@@ -13,7 +13,7 @@ These changes can be subscribed to at the [Atom (RSS) feed](/feed.xml)
 
 _All changes apply to the v2 APIs. The v1 API will not be updated from this point onwards._
 
-<% data.news.each.with_index do |news_item, index| %>
+<% data.news.sort_by(&:date).reverse.each.with_index do |news_item, index| %>
 <%= '---' if index > 0 %>
 ## <span class="govuk-caption-l"><%= news_item.date.strftime('%-d %B %Y') %></span> <span class="govuk-visually-hidden">-</span> <%= news_item.title %>
 <%= news_item.content %>

--- a/source/news.html.md.erb
+++ b/source/news.html.md.erb
@@ -1,9 +1,11 @@
 ---
-title: News
+title: Latest News
 ---
-# News
+# Latest News
 
-Recent changes to the Trade Tariff API
+Changes to the Trade Tariff API are listed below.
+
+These changes can be subscribed to at the [Atom (RSS) feed](/feed.xml)
 
 <% data.news.each.with_index do |news_item, index| %>
 <%= '---' if index > 0 %>

--- a/source/news.html.md.erb
+++ b/source/news.html.md.erb
@@ -1,6 +1,10 @@
 ---
 title: Latest News
 ---
+<% content_for :head do %>
+  <link href="/feed.xml" type="application/atom+xml" rel="alternate" title="Latest News Atom feed" />
+<% end %>
+
 # Latest News
 
 Changes to the Trade Tariff API are listed below.


### PR DESCRIPTION
### Jira link

[HOTT-1304](https://transformuk.atlassian.net/browse/HOTT-1304)

### What?

I have added/removed/altered:

- [x] Added a Latest News page
- [x] Added a News RSS feed
- [x] Linked the Latest News from the homepage
- [x] Updated the README to recommend updating the NEWS.yml file
- [x] Updated the README with missing deployment information

### Why?

I am doing this because:

- We want to be able to update our users with information about changes to the API