### PR TITLE
HOTT-1344 Dropped wrapping responses in <details>

### DIFF
--- a/templates/heading_example_responses.dot
+++ b/templates/heading_example_responses.dot
@@ -1,5 +1,4 @@
 ### Example Response
 
-<details>
-<summary>Examples</summary>
+
  

--- a/templates/responses.dot
+++ b/templates/responses.dot
@@ -1,5 +1,3 @@
-</details>
-
 ### Responses
 
 Status|Meaning|Description|Schema

--- a/templates/schema_sample.dot
+++ b/templates/schema_sample.dot
@@ -1,9 +1,4 @@
-<details>
-
-<summary>Sample JSON</summary>
-
 ```json
 {{=JSON.stringify(data.schema,null,2)}}
 ```
 
-</details>

--- a/templates/schema_sample.dot
+++ b/templates/schema_sample.dot
@@ -1,4 +1,8 @@
-```json
-{{=JSON.stringify(data.schema,null,2)}}
-```
-
+<details>
+  <summary>Sample JSON</summary>
+  <pre>
+    <code>
+    {{=JSON.stringify(data.schema,null,2)}}
+    </code>
+  </pre>
+</details>


### PR DESCRIPTION
### Jira link

[HOTT-1344](https://transformuk.atlassian.net/browse/HOTT-1344)

### What?

I have added/removed/altered:

- [x] Dropped wrapping code blocks in `<details>` tags

Update from @alexdesi :

The last commit makes the code block work within the collapsible icon.
We are using plain HTML because the markdown engine escapes the json block, making it not easy to read.

### Why?

I am doing this because:

- It breaks the syntax highlighting/code formatting when converting the markdown
