### PR TITLE
HOTT-1418: Document quota include param

### DIFF
--- a/source/v2/openapi.yaml
+++ b/source/v2/openapi.yaml
@@ -410,6 +410,15 @@ paths:
             Retrieve search page with number
           schema:
             type: integer
+        - name: include
+          in: query
+          required: false
+          description: |
+            Retrieve quota balance events which show the history of updates to the returned quota definition.
+          schema:
+            type: string
+            enum:
+            - quota_balance_events
 
       responses:
         200:


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1418

### What?

I have added/removed/altered:

- [x] Added documentation for /quotas/search include query param

### Why?

I am doing this because:

- This is required so clients of the api can know about this feature
