### PR TITLE
HOTT-1891 changes to accumulate permutations

### DIFF
--- a/source/v2/openapi.yaml
+++ b/source/v2/openapi.yaml
@@ -18,7 +18,7 @@ servers:
 paths:
   /sections:
     get:
-      summary: Retrieves all sections
+      summary: Retrieves all sections of the Tariff.
       description: |
         This resource represents _all sections_ in the Tariff.
 
@@ -1325,10 +1325,10 @@ components:
       properties:
         data:id:
           type: string
-          description: The `id` of the section. It may be used to uniquely identify a section and request it's section_note from the API.
+          description: The `id` of the section. It may be used to uniquely identify a section and request its section_note from the API.
         data:type:
           type: string
-          description: the type of object this is, e.g. `section`
+          description: the type of object, i.e. `section`
         data:attributes:
           type: array
           description: A collection of [referenced section objects](/reference.html#referencedsection "see referenced section object")
@@ -1364,10 +1364,10 @@ components:
       properties:
         data:id:
           type: string
-          description: The `id` of the section. It may be used to uniquely identify a section and request it's section_note from the API.
+          description: The `id` of the section. It may be used to uniquely identify a section and request its section_note from the API.
         data:type:
           type: string
-          description: The type of object this is, e.g. `section`
+          description: the type of object, i.e. `section`
         data:attributes:
           description: The section's attributes, as a [referenced section object](/reference.html#referencedsection "see referenced section object")
           $ref: '#/components/schemas/ReferencedSection'
@@ -1481,7 +1481,7 @@ components:
           description: The `id` of the chapter. This is a unique identifier.
         data:type:
           type: string
-          description: The type of object this is, e.g. `chapter`.
+          description: the type of object, i.e. `chapter`.
         data:attributes:
           type: array
           description: A collection of [referenced chapter objects](/reference.html#referencedchapter "see referenced chapter object")
@@ -1515,10 +1515,10 @@ components:
       properties:
         data:id:
           type: string
-          description: The `id` of the chapter. It may be used to uniquely identify a chapter and request it's chapter_note from the API.
+          description: The `id` of the chapter. It may be used to uniquely identify a chapter and request its chapter_note from the API.
         data:type:
           type: string
-          description: the type of object this is, e.g. `chapter`
+          description: the type of object, i.e. `chapter`
         data:attributes:
           description: The chapter's attributes, as a [referenced chapter object](/reference.html#referencedchapter "see referenced chapter object")
           $ref: '#/components/schemas/ReferencedChapter'
@@ -1628,10 +1628,10 @@ components:
       properties:
         data:id:
           type: string
-          description: The `id` of the heading. It may be used to uniquely identify a heading and request it's heading_note from the API.
+          description: The `id` of the heading. It may be used to uniquely identify a heading and request its heading_note from the API.
         data:type:
           type: string
-          description: the type of object this is, e.g. `heading`
+          description: the type of object, i.e. `heading`
         data:attributes:
           description: The heading's attributes, as a [referenced heading object](/reference.html#referencedheading "see referenced heading object")
           $ref: '#/components/schemas/ReferencedHeading'
@@ -1767,7 +1767,7 @@ components:
           description: The `id` of the commodity. It may be used to uniquely identify a commodity.
         data:type:
           type: string
-          description: the type of object this is, e.g. `commodity`
+          description: the type of object, i.e. `commodity`
         data:attributes:
           description: The commodity's attributes, as a [referenced commodity object](/reference.html#referencedcommodity "see referenced commodity object")
           $ref: '#/components/schemas/ReferencedCommodity'
@@ -1782,179 +1782,688 @@ components:
             # $ref: '#/components/schemas/ReferencedCommodity'
       example:
         data:
-          id: "27777"
+          id: '85314'
           type: commodity
           attributes:
-            producline_suffix: "80"
-            description: "Lambs (up to a year old)"
-            number_indents: 3
-            goods_nomenclature_item_id: "0104103000"
-            bti_url: "http://ec.europa.eu/taxation_customs/dds2/ebti/bti_consultation.jsp?Lang=en&nomenc=0104103000&Expand=true"
-            formatted_description: "Lambs (up to a year old)"
-            description_plain: "Lambs (up to a year old)"
+            producline_suffix: '80'
+            description: Frogs' legs
+            number_indents: 2
+            goods_nomenclature_item_id: '0208907000'
+            bti_url: >-
+              https://www.gov.uk/guidance/check-what-youll-need-to-get-a-legally-binding-decision-on-a-commodity-code
+            formatted_description: Frogs' legs
+            description_plain: Frogs' legs
             consigned: false
             consigned_from: null
-            basic_duty_rate: "<span title='80.5 EUR'>80.50</span> EUR / <abbr title='Hectokilogram'>100 kg</abbr>"
+            basic_duty_rate: null
             meursing_code: false
             declarable: true
           relationships:
             footnotes:
               data:
-              - id: "701"
-                type: footnote
+                - id: '701'
+                  type: footnote
             section:
               data:
-                id: "1"
+                id: '1'
                 type: section
             chapter:
               data:
-                id: "27623"
+                id: '27809'
                 type: chapter
             heading:
               data:
-                id: "27773"
+                id: '28267'
                 type: heading
             ancestors:
               data:
-              - id: "27774"
-                type: commodity
-              - id: "27776"
-                type: commodity
+                - id: '28275'
+                  type: commodity
             import_measures:
               data:
-              - id: "-480792"
-                type: measure
-              - id: "3619955"
-                type: measure
-              - id: "3563227"
-                type: measure
-              - id: "2046830"
-                type: measure
+                - id: '20098001'
+                  type: measure
             export_measures:
               data:
-              - id: "3540076"
-                type: measure
-              - id: "2982602"
-                type: measure
+                - id: '20180492'
+                  type: measure
+          meta:
+            duty_calculator:
+              applicable_additional_codes: {}
+              applicable_measure_units: {}
+              applicable_vat_options:
+                VATZ: VAT zero rate
+                VAT: Value added tax (20.0%)
+              entry_price_system: false
+              meursing_code: false
+              source: uk
+              trade_defence: false
+              zero_mfn_duty: false
         included:
-        - id: "27774"
-          type: commodity
-          attributes:
-            producline_suffix: "80"
-            description: "Sheep"
-            number_indents: 1
-            goods_nomenclature_item_id: "0104100000"
-            formatted_description: "Sheep"
-            description_plain: "Sheep"
-        - id: "701"
-          type: footnote
-          attributes:
-            code: "TR037"
-            description: "Guillotine blades"
-            formatted_description: "Guillotine blades"
-        - id: "1"
-          type: section
-          attributes:
-            numeral: "I"
-            title: "Live animals; animal products"
-            position: "1"
-        - id: "27773"
-          type: heading
-          attributes:
-            goods_nomenclature_item_id: "9950000000"
-            description: "Code used only in trading of... is less than €|200"
-            formatted_description: "Code used only in trading of... is less than €&nbsp;200"
-            description_plain: "Code used only in trading of... is less than € 200"
-        - id: "27623"
-          type: chapter
-          attributes:
-            goods_nomenclature_item_id: "0100000000"
-            description: "LIVE ANIMALS"
-            formatted_description: "Live animals"
-            chapter_note: "* 1\\. This chapter covers all live animals except:\r\n  * (a) fish and crustaceans, molluscs and other aquatic invertebrates, of heading 0301, 0306, 0307 or 0308;\r\n  * (b) cultures of micro-organisms and other products of heading 3002; and\r\n  * (c) animals of heading 9508."
-          relationships:
-            guides:
-              data:
-              - id: "23"
-                type: guide
-        - id: "3540076"
-          type: measure
-          attributes:
-            id: 3540076
-            origin: "eu"
-            effective_start_date: "2017-02-04T00:00:00.000Z"
-            effective_end_date: null
-            import: false
-            excise: false
-            vat: false
-            reduction_indicator: null
-          relationships:
-            duty_expression:
-              data:
-                id: "3540076-duty_expression"
-                type: duty_expression
-            measure_type:
-              data:
-                id: "715"
-                type: measure_type
-            legal_acts:
-              data:
-              - id: "R1701600"
-                type: legal_act
-              - id: "R9703380"
-                type: legal_act
-            measure_conditions:
-              data:
-              - id: "1134192"
-                type: measure_condition
-              - id: "1134193"
-                type: measure_condition
-              - id: "1134194"
-                type: measure_condition
-            measure_components:
-              data:
-              - id: "3540076-01"
-                type: measure_component
-              - id: "3540076-02"
-                type: measure_component
-            national_measurement_units:
-              data:
-            geographical_area:
-              data:
-                id: "1008"
-                type: geographical_area
-            excluded_countries:
-              data:
-            footnotes:
-              data:
-                id: "CD371"
-                type: footnote
-            order_number:
-              data: null
-        - id: "1134192"
-          type: measure_condition
-          attributes:
-            id: "1134192"
-            condition_code: "Y"
-            condition: "Y: Other conditions"
-            document_code: "N853"
-            requirement: "UN/EDIFACT certificates: Common Veterinary Entry Document (CVED) in accordance with Regulation (EC) No 136/2004, used for veterinary check on products"
-            action: "Import/export allowed after control"
-            duty_expression: ""
-        - id: "3540076-01"
-          type: measure_component
-          attributes:
-            id: "3540076-01"
-            duty_expression_id: "01"
-            duty_amount: 20.2
-            monetary_unit_code: "EUR"
-            monetary_unit_abbreviation: null
-            measurement_unit_code: "DTN"
-            duty_expression_description: "+ % or amount"
-            duty_expression_abbreviation: "+"
-        - id: ""
-          type: duty_expression
-          attributes:
+          - id: '1'
+            type: section
+            attributes:
+              numeral: I
+              title: Live animals; animal products
+              position: 1
+              section_note: "1. Any reference in this section to a particular genus or species of an animal, except where the context otherwise requires, includes a reference to the young of that genus or species.\r\n\r\n2. Except where the context otherwise requires, throughout the classification any reference to 'dried' products also covers products which have been dehydrated, evaporated or freeze-dried.\r\n"
+          - id: '27809'
+            type: chapter
+            attributes:
+              goods_nomenclature_item_id: '0200000000'
+              description: MEAT AND EDIBLE MEAT OFFAL
+              formatted_description: Meat and edible meat offal
+              chapter_note: "1. This chapter does not cover:\r\n\r\n   a) products of the kinds described in headings [0201](/headings/0201) to [0208](/headings/0208) or [0210](/headings/0210), unfit or unsuitable for human consumption;\r\n\r\n   b) edible, non-living insects (heading [0410](/headings/0410))\r\n\r\n   c) guts, bladders or stomachs of animals (heading [0504](/headings/0504)) or animal blood (heading [0511](/headings/0511) or [3002](/headings/3002)); or\r\n\r\n   d) animal fat, other than products of heading [0209](/headings/0209) ([Chapter 15](/chapters/15)).\r\n\r\n### Additional chapter notes\r\n\r\n1. A. The following expressions have the meanings hereby assigned to them:\r\n\r\n   (a) ‘carcases of bovine animals’, for the purposes of subheadings [0201 10](/subheadings/0201100000-80) and [0202 10](/subheadings/0202100000-80): whole carcases of the slaughtered animals after having been bled, eviscerated and skinned, imported with or without the heads, with or without the feet and with or without the other offal’s attached. Where carcases are imported without the heads, the latter must have been separated from the carcase at the atloido-occipital joint. When imported without the feet, the latter must have been cut off at the carpo-metacarpal or tarso-metatarsal joints; ‘carcase’ includes the front part of the carcase comprising all the bones and the scrag, neck and shoulder, having more than 10 pairs of ribs;\r\n\r\n   (b) ‘half-carcases of bovine animals’, for the purposes of subheadings [0201 10](/subheadings/0201100000-80) and [0202 10](/subheadings/0202100000-80): the product resulting from the symmetrical division of the whole carcase through the centre of each cervical, dorsal, lumbar and sacral vertebra and through the centre of the sternum and of the ischio-pubic symphysis; ‘halfcarcase’ includes the front part of the half-carcase comprising all the bones and the scrag, neck and shoulder, having more than 10 ribs;\r\n\r\n   (c) ‘compensated quarters’, for the purposes of subheadings [0201 20 20](/subheadings/0201202000-80) and [0202 20 10](/subheadings/0202201000-80): portions composed of either:\r\n\r\n      - forequarters comprising all the bones and the scrag, neck and shoulder, and cut at the tenth rib; and hindquarters comprising all the bones and the thigh and sirloin, and cut at the third rib, or\r\n\r\n      - forequarters comprising all the bones and the scrag, neck and shoulder, and cut at the fifth rib, with the whole of the flank and breast attached; and hindquarters comprising all the bones and the thigh and sirloin and cut at the eighth cut rib.\r\n      The forequarters and the hindquarters constituting ‘compensated quarters’ must be presented to customs at the same time and in equal numbers, and the total weight of the forequarters must be the same as that of the hindquarters; however, a difference between the weights of the two parts of the consignment is allowed, provided that this does not exceed 5 % of the weight of the heavier part (forequarters or hindquarters);\r\n\r\n   (d) ‘unseparated forequarters’, for the purposes of subheadings [0201 20 30](/subheadings/0201203000-80) and [0202 20 30](/subheadings/0202203000-80): the front part of a carcase, comprising all the bones and the scrag, neck and shoulder, with a minimum of four pairs of ribs and a maximum of 10 pairs of ribs (the first four pairs of ribs must be whole, the others may be cut), with or without the thin flank;\r\n\r\n   (e) ‘separated forequarters’, for the purposes of subheadings [0201 20 30](/subheadings/0201203000-80) and [0202 20 30](/subheadings/0202203000-80): the front part of a half-carcase, comprising all the bones and the scrag, neck and shoulder, with a minimum of four ribs and a maximum of 10 ribs (the first four ribs must be whole, the others may be cut), with or without the thin flank;\r\n\r\n   (f) ‘unseparated hindquarters’, for the purposes of subheadings [0201 20 50](/subheadings/0201205000-80) and [0202 20 50](/subheadings/0202205000-80): the rear part of a carcase comprising all the bones and the thigh and sirloin, including the fillet, with a minimum of three pairs of whole or cut ribs, with or without the shank and with or without the thin flank;\r\n\r\n   (g) ‘separated hindquarters’, for the purposes of subheadings [0201 20 50](/subheadings/0201205000-80) and [0202 20 50](/subheadings/0202205000-80): the rear part of a half-carcase, comprising all the bones and the thigh and sirloin, including the fillet, with a minimum of three whole or cut ribs, with or without the shank and with or without the thin flank;\r\n\r\n   (h) 1. ‘crop’ and ‘chuck and blade’ cuts, for the purposes of subheading [0202 30 50](/subheadings/0202305000-80): the dorsal part of the forequarter, including the upper part of the shoulder, obtained from a forequarter with a minimum of four ribs and a maximum of 10 ribs by a cut along a straight line through the point where the first rib joins the first sternal segment to the point of reflection of the diaphragm on the tenth rib;\r\n\r\n2. ‘brisket’ cut, for the purposes of subheading [0202 30 50](/subheadings/0202305000-80): the lower part of the forequarter, comprising the brisket navel end and the brisket point end.\r\n\r\n   B. Products covered by additional chapter notes 1(A)(a) to (g) to this chapter may be presented with or without the vertebral column.\r\n\r\n   C. In determining the number of whole or cut ribs referred to in additional chapter note 1(A), only those attached to the vertebral column are to be taken into consideration. If the vertebral column has been removed, only the whole or cut ribs which otherwise would have been directly attached to the vertebral column are to be taken into consideration.\r\n\r\n   2. A. The following expressions have the meanings hereby assigned to them:\r\n\r\n      (a) ‘carcases or half-carcases’, for the purposes of subheadings [0203 11 10](/subheadings/0203111000-80) and [0203 21 10](/subheadings/0203211000-80): slaughtered pigs, in the form of carcases of domestic swine which have been bled and eviscerated and from which the bristles and hooves have been removed. Half-carcases are derived from whole carcases by division through each cervical, dorsal, lumbar and sacral vertebra, through or along the sternum and through the ischio-pubic symphysis. These carcases or half-carcases may be with or without head, with or without the chaps, feet, flare fat, kidneys, tail or diaphragm. Half-carcases may be with or without spinal cord, brain or tongue. Carcases and half-carcases of sows may be with or without udders (mammary glands);\r\n\r\n      (b) ‘hams’ (legs), for the purposes of subheadings [0203 12 11](/subheadings/0203121100-80), [0203 22 11](/subheadings/0203221100-80), [0210 11 11](/subheadings/0210111100-80) and [0210 11 31](/subheadings/0210113100-80): the posterior (caudal) part of the half-carcase, including bones, with or without the foot, shank, rind or subcutaneous fat. The ham (leg) is separated from the rest of the half-carcase, so that it includes, at most, the last lumbar vertebra;\r\n\r\n      (c) ‘fore-ends’, for the purposes of subheadings [0203 19 11](/subheadings/0203191100-80), [0203 29 11](/subheadings/0203291100-80), [0210 19 30](/subheadings/0210193000-80) and [0210 19 60](/subheadings/0210196000-80): the anterior (cranial) part of the half-carcase without the head, with or without the chaps, including bones, with or without foot, shank, rind or subcutaneous fat. The fore-end is separated from the rest of the half-carcase, so that it includes, at most, the fifth dorsal vertebra. The upper (dorsal) part of the fore-end, whether or not containing the blade-bone and attached muscles (neckend in fresh or collar in salted condition), is considered a cut of the loin, when it is separated from the lower (ventral) part of the fore-end, at most by a cut just below the vertebral column;\r\n\r\n      (d) ‘shoulders’, for the purposes of subheadings [0203 12 19](/subheadings/0203121900-80), [0203 22 19](/subheadings/0203221900-80), [0210 11 19](/subheadings/0210111900-80) and [0210 11 39](/subheadings/0210113900-80): the lower part of the fore-end whether or not containing the blade-bone and attached muscles, including bones, with or without foot, shank, rind or subcutaneous fat. The blade-bone and attached muscles, presented separately, remain classified in this subheading as a part of the shoulder;\r\n\r\n      (e) ‘loins’, for the purposes of subheadings [0203 19 13](/subheadings/0203191300-80), [0203 29 13](/subheadings/0203291300-80), [0210 19 40](/subheadings/0210194000-80) and [0210 19 70](/subheadings/0210197000-80): the upper part of the half-carcase, extending from the first cervical vertebra to the caudal vertebrae, including bones, with or without the tenderloin, blade-bone, subcutaneous fat or rind. The loin is separated from the lower part of the half-carcase by a cut just below the vertebral column;\r\n\r\n      (f) ‘bellies’, for the purposes of subheadings [0203 19 15](/subheadings/0203191500-80), [0203 29 15](/subheadings/0203291500-80), [0210 12 11](/subheadings/0210121100-80) and [0210 12 19](/subheadings/0210121900-80): the lower part of the half-carcase situated between the ham (leg) and the shoulder, commonly known as ‘streaky’, with or without bones, but with the rind and the subcutaneous fat;\r\n\r\n      (g) ‘bacon sides’, for the purposes of subheading [0210 19 10](/subheadings/0210191000-80): the pig half-carcase without the head, cheek, chap, feet, tail, flare fat, kidney, tenderloin, blade-bone, sternum, vertebral column, pelvic bone and diaphragm;\r\n\r\n      (h) ‘spencers’, for the purposes of subheading [0210 19 10](/subheadings/0210191000-80): the bacon side without the ham, whether or not boned;\r\n\r\n      (ij) ‘three-quarter sides’, for the purposes of subheading [0210 19 20](/subheadings/0210192000-80): the bacon side without the fore-end, whether or not boned;\r\n\r\n      (k) ‘middles’, for the purposes of subheading [0210 19 20](/subheadings/0210192000-80): the bacon side without the ham and the fore-end, whether or not boned. The subheading also includes cuts of middles containing tissue of loin and belly in natural proportion to the entire middles.\r\n\r\n   B. The parts of the cuts defined in paragraph 2(A)(f) fall in the same subheadings, only if they contain rind and subcutaneous fat. If the cuts falling in subheadings [0210 11 11](/subheadings/0210111100-80), [0210 11 19](/subheadings/0210111900-80), [0210 11 31](/subheadings/0210113100-80), [0210 11 39](/subheadings/0210113900-80), [0210 19 30](/subheadings/0210193000-80) and [0210 19 60](/subheadings/0210196000-80) are derived from a bacon side from which the bones indicated under paragraph 2(A)(g) have already been removed, the lines of cutting must follow those defined under paragraph 2(A)(b), (c) and (d) accordingly; in any case, these cuts or parts thereof must contain bones.\r\n\r\n   C. Subheadings [0206 49 00](/subheadings/0206490000-80) and [0210 99 49](/subheadings/0210994900-80), include, in particular, heads or halves of heads of domestic swine, with or without the brains, cheeks or tongues, and parts thereof. The head is separated from the rest of the half-carcase as follows:\r\n\r\n      - by a straight cut parallel to the cranium; or\r\n\r\n      - by a cut parallel to the cranium up to the level of the eyes and then inclined to the front of the head, thereby causing the chaps to remain attached to the half-carcase. The cheeks, snouts and ears as well as the meat attached to the head, particularly to the rear part, are considered parts of heads. \r\n\r\n   However, the cuts of boneless meat of the fore-end, presented alone (jowls, chaps, or chaps and jowls together), fall in subheading [0203 19 55](/subheadings/0203195500-80), [0203 29 55](/subheadings/0203295500-80), [0210 19 50](/subheadings/0210195000-80) or [0210 19 81](/subheadings/0210198100-80), as the case may be.\r\n\r\n   D. For the purposes of subheadings [0209 10 11](/subheadings/0209101100-80) and [0209 10 19](/subheadings/0209101900-80), ‘subcutaneous pig fat’ has the meaning of the fatty tissue which accumulates under the rind of the pig and adheres to it, irrespective of the part of the pig from which it comes; in any case, the weight of the fatty tissue must exceed the weight of the rind. These subheadings also include subcutaneous pig fat from which the rind has been removed.\r\n\r\n   E. For the purposes of subheadings [0210 11 31](/subheadings/0210113100-80), [0210 11 39](/subheadings/0210113900-80), [0210 12 19](/subheadings/0210121900-80) and [0210 19 60](/subheadings/0210196000-80) to [0210 19 89](/subheadings/0210198900-80), products in which the water/protein ratio in the meat (nitrogen content × 6.25) is 2.8 or less is considered as ‘dried or smoked’. The nitrogen content is determined in accordance with ISO method 937-1978. \r\n\r\n3. A. For the purposes of heading 0204, the following expressions have the meanings hereby assigned to them:\r\n\r\n      (a) ‘carcases’, for the purposes of subheadings [0204 10](/subheadings/0204100000-80), [0204 21](/subheadings/0204210000-80), [0204 30](/subheadings/0204300000-80), [0204 41](/subheadings/0204410000-80), [0204 50 11](/subheadings/0204501100-80) and [0204 50 51](/subheadings/0204505100-80): whole carcases of the slaughtered animals after having been bled, eviscerated and skinned, imported with or without the heads, with or without the feet and with or without the other offal’s attached. Where carcases are imported without the heads, the latter must have been separated from the carcase at the atloidooccipital joint. When imported without the feet, the latter must have been cut off at the carpo-metacarpal or tarso-metatarsal joints;\r\n\r\n      (b) ‘half-carcases’, for the purposes of subheadings [0204 10](/subheadings/0204100000-80), [0204 21](/subheadings/0204210000-80), [0204 30](/subheadings/0204300000-80), [0204 41](/subheadings/0204410000-80), [0204 50 11](/subheadings/0204501100-80) and [0204 50 51](/subheadings/0204505100-80): the product resulting from the symmetrical division of the whole carcase through the centre of each cervical, dorsal, lumbar and sacral vertebra and through the centre of the sternum and of the ischiopubic symphysis;\r\n\r\n      (c) ‘short-forequarters’, for the purposes of subheadings [0204 22 10](/subheadings/0204221000-80), [0204 42 10](/subheadings/0204421000-80), [0204 50 13](/subheadings/0204501300-80) and [0204 50 53](/subheadings/0204505300-80): the anterior part of the carcase, with or without the breast, including all the bones and the shoulders, scrag and middle neck, cut at right angles to the backbone, with a minimum of five and a maximum of seven pairs of whole or cut ribs;\r\n\r\n      (d) ‘short-forequarters’, for the purposes of subheadings [0204 22 10](/subheadings/0204221000-80), [0204 42 10](/subheadings/0204421000-80), [0204 50 13](/subheadings/0204501300-80) and [0204 50 53](/subheadings/0204505300-80): the anterior part of the half-carcase, with or without the breast, including all the bones and the shoulder, scrag and middle neck, cut at right angles to the backbone, with a minimum of five and a maximum of seven whole or cut ribs;\r\n\r\n      (e) ‘chines and/or best ends’, for the purposes of subheadings [0204 22 30](/subheadings/0204223000-80), [0204 42 30](/subheadings/0204423000-80), [0204 50 15](/subheadings/0204501500-80) and [0204 50 55](/subheadings/0204505500-80): the remaining part of the carcase after the legs and short-forequarters have been removed, with or without the kidneys; the chines, when separated from the best ends, must include a minimum of five lumbar vertebrae; the best ends, when separated from the chines, must include a minimum of five pairs of whole or cut ribs;\r\n\r\n      (f) ‘chine and/or best end’, for the purposes of subheadings [0204 22 30](/subheadings/0204223000-80), [0204 42 30](/subheadings/0204423000-80), [0204 50 15](/subheadings/0204501500-80) and [0204 50 55](/subheadings/0204505500-80): the remaining part of the half-carcase after the legs and short-forequarters have been removed, with or without the kidney; the chine, when separated from the best end, must include a minimum of five lumbar vertebrae; the best end, when separated from the chine, must include a minimum of five whole or cut ribs;\r\n\r\n      (g) ‘legs’, for the purposes of subheadings [0204 22 50](/subheadings/0204225000-80), [0204 42 50](/subheadings/0204425000-80), [0204 50 19](/subheadings/0204501900-80) and [0204 50 59](/subheadings/0204505900-80): the rear part of the carcase, comprising all the bones and the legs and cut at right angles to the backbone at the sixth lumbar vertebra just under the ilium or at the fourth sacral vertebra through the ilium anterior to the ischiopubic symphysis;\r\n\r\n      (h) ‘legs’, for the purposes of subheadings [0204 22 50](/subheadings/0204225000-80), [0204 42 50](/subheadings/0204425000-80), [0204 50 19](/subheadings/0204501900-80) and [0204 50 59](/subheadings/0204505900-80): the rear part of the half-carcase comprising all the bones and the leg cut at right angles to the backbone at the sixth lumbar vertebra just under the ilium or at the fourth sacral vertebra through the ilium anterior to the ischio-pubic symphysis.\r\n\r\n   B. In determining the number of whole or cut ribs referred to in paragraph 3 A, only those attached to the backbone are to be taken into consideration.\r\n\r\n4. The following expressions have the meanings hereby assigned to them:\r\n\r\n   (a) ‘poultry cuts, with bone in’, for the purposes of subheadings [0207 13 20](/subheadings/0207132000-80) to [0207 13 60](/subheadings/0207136000-80), [0207 14 20](/subheadings/0207142000-80) to [0207 14 60](/subheadings/0207146000-80), [0207 26 20](/subheadings/0207262000-80) to [0207 26 70](/subheadings/0207267000-80), [0207 27 20](/subheadings/0207272000-80) to [0207 27 70](/subheadings/0207277000-80), [0207 44 21](/subheadings/0207442100-80) to [0207 44 61](/subheadings/0207446100-80), [0207 45 21](/subheadings/0207452100-80) to [0207 45 61](/subheadings/0207456100-80), [0207 54 21](/subheadings/0207542100-80) to [0207 54 61](/subheadings/0207546100-80), [0207 55 21](/subheadings/0207552100-80) to [0207 55 61](/subheadings/0207556100-80) and [0207 60 21](/subheadings/0207602100-80) to [0207 60 61](/subheadings/0207606100-80): the cuts specified therein, including all bones. Poultry cuts as referred to in (a) which have been partly boned fall in subheading [0207 13 70](/subheadings/0207137000-80), [0207 14 70](/subheadings/0207147000-80), [0207 26 80](/subheadings/0207268000-80), [0207 27 80](/subheadings/0207278000-80), [0207 44 71](/subheadings/0207447100-80), [0207 44 81](/subheadings/0207448100-80), [0207 45 71](/subheadings/0207457100-80), [0207 45 81](/subheadings/0207458100-80), [0207 54 71](/subheadings/0207547100-80), [0207 54 81](/subheadings/0207548100-80), [0207 55 71](/subheadings/0207557100-80), [0207 55 81](/subheadings/0207558100-80) and [0207 60 81](/subheadings/0207608100-80);\r\n\r\n   (b) ‘halves’, for the purposes of subheadings [0207 13 20](/subheadings/0207132000-80), [0207 14 20](/subheadings/0207142000-80), [0207 26 20](/subheadings/0207262000-80), [0207 27 20](/subheadings/0207272000-80), [0207 44 21](/subheadings/0207442100-80), [0207 45 21](/subheadings/0207452100-80), [0207 54 21](/subheadings/0207542100-80), [0207 55 21](/subheadings/0207552100-80) and [0207 60 21](/subheadings/0207602100-80): halves of poultry carcases, obtained by a longitudinal cut in a plane along the sternum and the backbone;\r\n\r\n   (c) ‘quarters’, for the purposes of subheadings [0207 13 20](/subheadings/0207132000-80), [0207 14 20](/subheadings/0207142000-80), [0207 26 20](/subheadings/0207262000-80), [0207 27 20](/subheadings/0207272000-80), [0207 44 21](/subheadings/0207442100-80), [0207 45 21](/subheadings/0207452100-80), [0207 54 21](/subheadings/0207542100-80), [0207 55 21](/subheadings/0207552100-80) and [0207 60 21](/subheadings/0207602100-80): leg quarters or breast quarters, obtained by a transversal cut of a half;\r\n\r\n   (d) ‘whole wings, with or without tips’, for the purposes of subheadings [0207 13 30](/subheadings/0207133000-80), [0207 14 30](/subheadings/0207143000-80), [0207 26 30](/subheadings/0207263000-80), [0207 27 30](/subheadings/0207273000-80), [0207 44 31](/subheadings/0207443100-80), [0207 45 31](/subheadings/0207453100-80), [0207 54 31](/subheadings/0207543100-80), [0207 55 31](/subheadings/0207553100-80) and [0207 60 31](/subheadings/0207603100-80): poultry cuts, consisting of the humerus, radius and ulna, together with the surrounding musculature. The tip, including the carpal bones, may or may not have been removed. The cuts must have been made at the joints;\r\n\r\n   (e) ‘breasts’, for the purposes of subheadings [0207 13 50](/subheadings/0207135000-80), [0207 14 50](/subheadings/0207145000-80), [0207 26 50](/subheadings/0207265000-80), [0207 27 50](/subheadings/0207275000-80), [0207 44 51](/subheadings/0207445100-80), [0207 45 51](/subheadings/0207455100-80), [0207 54 51](/subheadings/0207545100-80), [0207 55 51](/subheadings/0207555100-80) and [0207 60 51](/subheadings/0207605100-80): poultry cuts, consisting of the sternum and the ribs distributed on both sides of it, together with the surrounding musculature;\r\n\r\n   (f) ‘legs’, for the purposes of subheadings [0207 13 60](/subheadings/0207136000-80), [0207 14 60](/subheadings/0207146000-80), [0207 44 61](/subheadings/0207446100-80), [0207 45 61](/subheadings/0207456100-80), [0207 54 61](/subheadings/0207546100-80), [0207 55 61](/subheadings/0207556100-80) and [0207 60 61](/subheadings/0207606100-80): poultry cuts consisting of the femur, tibia and fibula, together with the surrounding musculature. The two cuts must have been made at the joints;\r\n\r\n   (g) ‘turkey drumsticks’, for the purposes of subheadings [0207 26 60](/subheadings/0207266000-80) and [0207 27 60](/subheadings/0207276000-80): turkey cuts, consisting of the tibia and fibula, together with the surrounding musculature. The two cuts must have been made at the joints;\r\n\r\n   (h) ‘turkey legs, other than drumsticks’, for the purposes of subheadings [0207 26 70](/subheadings/0207267000-80) and [0207 27 70](/subheadings/0207277000-80): turkey cuts, consisting of the femur together with the surrounding musculature or of the femur, tibia and fibula, together with the surrounding musculature. The two cuts must have been made at the joints;\r\n\r\n   (ij) ‘duck or goose paletots’, for the purposes of subheadings [0207 44 71](/subheadings/0207447100-80), [0207 45 71](/subheadings/0207457100-80), [0207 54 71](/subheadings/0207547100-80) and [0207 55 71](/subheadings/0207557100-80): ducks or geese, plucked and completely drawn, without heads or feet, with carcase bones (breastbone, ribs, backbone and sacrum) removed, but with the femurs, tibias and humeri.\r\n\r\n5. (a) Uncooked seasoned meats fall in [Chapter 16](/chapters/16). ‘Seasoned meat’ is uncooked meat that has been seasoned, either in depth or over the whole surface of the product, with seasoning either visible to the naked eye or clearly distinguishable by taste.\r\n\r\n   (b) Products falling in heading 0210 to which seasoning has been added during the process of preparation remain classified therein, provided that the addition of seasoning has not changed their character.\r\n\r\n6. For the purposes of subheadings [0210 11](/subheadings/0210110000-80) to [0210 93](/subheadings/0210930000-80), the term ‘meat and edible meat offal, salted or in brine’ means meat and edible meat offal deeply and homogeneously impregnated with salt in all parts and having a total salt content by weight of 1.2% or more, provided that it is the salting which ensures the long-term preservation. For the purposes of subheading [0210 99](/subheadings/0210990000-80), the term ‘meat and edible meat offal, salted or in brine’ means meat and edible meat offal deeply and homogeneously impregnated with salt in all parts and having a total salt content by weight of 1.2% or more.\r\n"
+            relationships:
+              guides:
+                data: []
+          - id: '701'
+            type: footnote
+            attributes:
+              code: TN701
+              description: >-
+                According to the Council Regulation (EU) No 692/2014 (OJ L183, p. 9) it
+                shall be prohibited to import into European Union goods originating in
+                Crimea or Sevastopol.<br>The prohibition shall not apply in respect of:
+                <br>(a) the execution until 26 September 2014, of trade contracts
+                concluded before 25 June 2014, or of ancillary contracts necessary for
+                the execution of such contracts, provided that the natural or legal
+                persons, entity or body seeking to perform the contract have notified,
+                at least 10 working days in advance, the activity or transaction to the
+                competent authority of the Member State in which they are established.
+                <br>(b) goods originating in Crimea or Sevastopol which have been made
+                available to the Ukrainian authorities for examination, for which
+                compliance with the conditions conferring entitlement to preferential
+                origin has been verified and for which a certificate of origin has been
+                issued in accordance with Regulation (EU) No 978/2012 and Regulation
+                (EU) No 374/2014 or in accordance with the EU-Ukraine Association
+                Agreement.
+              formatted_description: >-
+                According to the Council Regulation (EU) No 692/2014 (OJ L183, p. 9) it
+                shall be prohibited to import into European Union goods originating in
+                Crimea or Sevastopol.<br>The prohibition shall not apply in respect of:
+                <br>(a) the execution until 26 September 2014, of trade contracts
+                concluded before 25 June 2014, or of ancillary contracts necessary for
+                the execution of such contracts, provided that the natural or legal
+                persons, entity or body seeking to perform the contract have notified,
+                at least 10 working days in advance, the activity or transaction to the
+                competent authority of the Member State in which they are established.
+                <br>(b) goods originating in Crimea or Sevastopol which have been made
+                available to the Ukrainian authorities for examination, for which
+                compliance with the conditions conferring entitlement to preferential
+                origin has been verified and for which a certificate of origin has been
+                issued in accordance with Regulation (EU) No 978/2012 and Regulation
+                (EU) No 374/2014 or in accordance with the EU-Ukraine Association
+                Agreement.
+          - id: 20098001-duty_expression
+            type: duty_expression
+            attributes:
+              base: ''
+              formatted_base: ''
+          - id: '410'
+            type: measure_type
+            attributes:
+              description: Veterinary control
+              measure_type_series_id: B
+              measure_component_applicable_code: 2
+              order_number_capture_code: 2
+              trade_movement_code: 0
+              validity_end_date: null
+              validity_start_date: '2012-04-01T00:00:00.000Z'
+              id: '410'
+              measure_type_series_description: Entry into free circulation or exportation subject to conditions
+          - id: C2100270
+            type: legal_act
+            attributes:
+              validity_start_date: '2021-01-01T00:00:00.000Z'
+              validity_end_date: null
+              officialjournal_number: '1'
+              officialjournal_page: 1
+              published_date: '2021-01-01'
+              regulation_code: C0027/21
+              regulation_url: ''
+              description: null
+          - id: '20060275'
+            type: measure_condition
+            attributes:
+              action: Import/export allowed after control
+              action_code: '29'
+              certificate_description: >-
+                UN/EDIFACT certificates: Common Health Entry Document for Products
+                (CHED-P) (as set out in Part 2, Section B of Annex II to Commission
+                Implementing Regulation (EU) 2019/1715 (OJ L 261)) as transposed into UK
+                Law.
+              condition: 'B: Presentation of a certificate/licence/document'
+              condition_code: B
+              condition_duty_amount: null
+              condition_measurement_unit_code: null
+              condition_measurement_unit_qualifier_code: null
+              condition_monetary_unit_code: null
+              document_code: N853
+              duty_expression: ''
+              guidance_cds: >-
+                - Enter GBCHDyyyy. and the reference number of the CHED-P.
+
+
+                - A separate N853 entry in DE 2/3 is required for each individual CHED-P
+
+
+                - Note yyyy. represents the year in which the licence was issued, for
+                example GBCHD2021.
+
+
+                - The '.' after the year is part of the licence completion requirements
+
+
+                - Use one of the following [document status
+                codes](https://www.gov.uk/government/publications/uk-trade-tariff-document-status-codes-for-harmonised-declarations/uk-trade-tariff-document-status-codes-for-harmonised-declarations):
+                <abbr title='Document attached - exhausted by (or only applies to) this
+                entry (document returned to the trader)'>AE</abbr>, <abbr
+                title='Document held by authorised trader - already attributed on
+                simplified declaration'>JA</abbr>, <abbr title='Document held by
+                authorised trader - exhausted by (or only applies to) this
+                entry'>JE</abbr>, <abbr title='Lodged previously - exhausted by (or only
+                applies to) this entry'>LE</abbr>, <abbr title='Lodged previously - part
+                use (applies to this and other entries)'>LP</abbr>, <abbr
+                title='Ex-heading goods for which the document does not apply'>XX</abbr>
+              guidance_chief: >-
+                - Use [status
+                code](https://www.gov.uk/government/publications/uk-trade-tariff-document-status-codes-for-harmonised-declarations/uk-trade-tariff-document-status-codes-for-harmonised-declarations)
+                <abbr title='Document attached - exhausted by (or only applies to) this
+                entry (document returned to the trader)'>AE</abbr>, <abbr
+                title='Document held by authorised trader - already attributed on
+                simplified declaration'>JA</abbr>, <abbr title='Document held by
+                authorised trader - exhausted by (or only applies to) this
+                entry'>JE</abbr>, <abbr title='Lodged previously - exhausted by (or only
+                applies to) this entry'>LE</abbr>, <abbr title='Lodged previously - part
+                use (applies to this and other entries)'>LP</abbr> or <abbr
+                title='Ex-heading goods for which the document does not apply'>XX</abbr>
+                as appropriate.
+              measure_condition_class: document
+              monetary_unit_abbreviation: null
+              requirement: >-
+                UN/EDIFACT certificates: UN/EDIFACT certificates: Common Health Entry
+                Document for Products (CHED-P) (as set out in Part 2, Section B of Annex
+                II to Commission Implementing Regulation (EU) 2019/1715 (OJ L 261)) as
+                transposed into UK Law.
+            relationships:
+              measure_condition_components:
+                data: []
+          - id: '20060277'
+            type: measure_condition
+            attributes:
+              action: Import/export allowed after control
+              action_code: '29'
+              certificate_description: >-
+                Exemption by virtue of Article 7 of Commission Delegated Regulation
+                2019/2122 (Goods which form part of passengers' personal luggage and are
+                intended for personal consumption or use)
+              condition: 'B: Presentation of a certificate/licence/document'
+              condition_code: B
+              condition_duty_amount: null
+              condition_measurement_unit_code: null
+              condition_measurement_unit_qualifier_code: null
+              condition_monetary_unit_code: null
+              document_code: Y058
+              duty_expression: ''
+              guidance_cds: >-
+                - Complete the statement: 'Exempt personal consignment' in the Document
+                Identifier (Second Component).
+
+
+                - Document Reason (Fourth Component) must be left blank.
+
+
+                - Use of this code constitutes a legal declaration that the goods meet
+                the criteria for an exemption under Article 7 of Commission Delegated
+                Regulation 2019/2122 (Goods which form part of passengers personal
+                luggage and are intended for personal consumption or use).
+
+
+                - Sufficient evidence must be held to demonstrate eligibility for this
+                exemption which must be produced on demand.
+
+
+                - No document status code is required.
+              guidance_chief: This document code is available on CDS only.
+              measure_condition_class: exemption
+              monetary_unit_abbreviation: null
+              requirement: >-
+                Particular provisions: Exemption by virtue of Article 7 of Commission
+                Delegated Regulation 2019/2122 (Goods which form part of passengers'
+                personal luggage and are intended for personal consumption or use)
+            relationships:
+              measure_condition_components:
+                data: []
+          - id: '20060278'
+            type: measure_condition
+            attributes:
+              action: Import/export allowed after control
+              action_code: '29'
+              certificate_description: >-
+                Exemption by virtue of Articles 3 and 4 of regulation 2019/2122 (animals
+                intended for scientific purposes, research and diagnostic samples)
+              condition: 'B: Presentation of a certificate/licence/document'
+              condition_code: B
+              condition_duty_amount: null
+              condition_measurement_unit_code: null
+              condition_measurement_unit_qualifier_code: null
+              condition_monetary_unit_code: null
+              document_code: C084
+              duty_expression: ''
+              guidance_cds: >-
+                - Complete the statement 'regulation 2019/2122 exempt'.
+
+
+                - Use of this code constitutes a legal declaration that the goods are
+                not concerned by Commission Delegated Regulation (EU) 2019/2122 adopting
+                a list of animals and goods exempt from official controls at border
+                control posts.
+
+
+                - Sufficient evidence must be held in records to demonstrate eligibility
+                for this waiver which must be produced on demand.
+
+
+                - No document status code is required.
+              guidance_chief: This document code is available on CDS only.
+              measure_condition_class: unknown
+              monetary_unit_abbreviation: null
+              requirement: >-
+                Other certificates: Exemption by virtue of Articles 3 and 4 of
+                regulation 2019/2122 (animals intended for scientific purposes, research
+                and diagnostic samples)
+            relationships:
+              measure_condition_components:
+                data: []
+          - id: '20060281'
+            type: measure_condition
+            attributes:
+              action: Import/export not allowed after control
+              action_code: '09'
+              certificate_description: null
+              condition: 'B: Presentation of a certificate/licence/document'
+              condition_code: B
+              condition_duty_amount: null
+              condition_measurement_unit_code: null
+              condition_measurement_unit_qualifier_code: null
+              condition_monetary_unit_code: null
+              document_code: ''
+              duty_expression: ''
+              guidance_cds: null
+              guidance_chief: null
+              measure_condition_class: negative
+              monetary_unit_abbreviation: null
+              requirement: null
+            relationships:
+              measure_condition_components:
+                data: []
+          - id: '20060274'
+            type: measure_condition
+            attributes:
+              action: Import/export allowed after control
+              action_code: '29'
+              certificate_description: >-
+                UN/EDIFACT certificates: Common Health Entry Document for Products
+                (CHED-P) (as set out in Part 2, Section B of Annex II to Commission
+                Implementing Regulation (EU) 2019/1715 (OJ L 261)) as transposed into UK
+                Law.
+              condition: >-
+                E: The quantity or the price per unit declared, as appropriate, is equal
+                or less than the specified maximum, or presentation of the required
+                document
+              condition_code: E
+              condition_duty_amount: null
+              condition_measurement_unit_code: null
+              condition_measurement_unit_qualifier_code: null
+              condition_monetary_unit_code: null
+              document_code: N853
+              duty_expression: ''
+              guidance_cds: >-
+                - Enter GBCHDyyyy. and the reference number of the CHED-P.
+
+
+                - A separate N853 entry in DE 2/3 is required for each individual CHED-P
+
+
+                - Note yyyy. represents the year in which the licence was issued, for
+                example GBCHD2021.
+
+
+                - The '.' after the year is part of the licence completion requirements
+
+
+                - Use one of the following [document status
+                codes](https://www.gov.uk/government/publications/uk-trade-tariff-document-status-codes-for-harmonised-declarations/uk-trade-tariff-document-status-codes-for-harmonised-declarations):
+                <abbr title='Document attached - exhausted by (or only applies to) this
+                entry (document returned to the trader)'>AE</abbr>, <abbr
+                title='Document held by authorised trader - already attributed on
+                simplified declaration'>JA</abbr>, <abbr title='Document held by
+                authorised trader - exhausted by (or only applies to) this
+                entry'>JE</abbr>, <abbr title='Lodged previously - exhausted by (or only
+                applies to) this entry'>LE</abbr>, <abbr title='Lodged previously - part
+                use (applies to this and other entries)'>LP</abbr>, <abbr
+                title='Ex-heading goods for which the document does not apply'>XX</abbr>
+              guidance_chief: >-
+                - Use [status
+                code](https://www.gov.uk/government/publications/uk-trade-tariff-document-status-codes-for-harmonised-declarations/uk-trade-tariff-document-status-codes-for-harmonised-declarations)
+                <abbr title='Document attached - exhausted by (or only applies to) this
+                entry (document returned to the trader)'>AE</abbr>, <abbr
+                title='Document held by authorised trader - already attributed on
+                simplified declaration'>JA</abbr>, <abbr title='Document held by
+                authorised trader - exhausted by (or only applies to) this
+                entry'>JE</abbr>, <abbr title='Lodged previously - exhausted by (or only
+                applies to) this entry'>LE</abbr>, <abbr title='Lodged previously - part
+                use (applies to this and other entries)'>LP</abbr> or <abbr
+                title='Ex-heading goods for which the document does not apply'>XX</abbr>
+                as appropriate.
+              measure_condition_class: document
+              monetary_unit_abbreviation: null
+              requirement: >-
+                UN/EDIFACT certificates: UN/EDIFACT certificates: Common Health Entry
+                Document for Products (CHED-P) (as set out in Part 2, Section B of Annex
+                II to Commission Implementing Regulation (EU) 2019/1715 (OJ L 261)) as
+                transposed into UK Law.
+            relationships:
+              measure_condition_components:
+                data: []
+          - id: '20060276'
+            type: measure_condition
+            attributes:
+              action: Import/export allowed after control
+              action_code: '29'
+              certificate_description: null
+              condition: >-
+                E: The quantity or the price per unit declared, as appropriate, is equal
+                or less than the specified maximum, or presentation of the required
+                document
+              condition_code: E
+              condition_duty_amount: 2
+              condition_measurement_unit_code: KGM
+              condition_measurement_unit_qualifier_code: null
+              condition_monetary_unit_code: null
+              document_code: ''
+              duty_expression: ''
+              guidance_cds: null
+              guidance_chief: null
+              measure_condition_class: threshold
+              monetary_unit_abbreviation: null
+              requirement: <span>2.00</span> <abbr title='Kilogram'>kg</abbr>
+            relationships:
+              measure_condition_components:
+                data: []
+          - id: '20060279'
+            type: measure_condition
+            attributes:
+              action: Import/export allowed after control
+              action_code: '29'
+              certificate_description: >-
+                Exemption by virtue of Articles 3 and 4 of regulation 2019/2122 (animals
+                intended for scientific purposes, research and diagnostic samples)
+              condition: >-
+                E: The quantity or the price per unit declared, as appropriate, is equal
+                or less than the specified maximum, or presentation of the required
+                document
+              condition_code: E
+              condition_duty_amount: null
+              condition_measurement_unit_code: null
+              condition_measurement_unit_qualifier_code: null
+              condition_monetary_unit_code: null
+              document_code: C084
+              duty_expression: ''
+              guidance_cds: >-
+                - Complete the statement 'regulation 2019/2122 exempt'.
+
+
+                - Use of this code constitutes a legal declaration that the goods are
+                not concerned by Commission Delegated Regulation (EU) 2019/2122 adopting
+                a list of animals and goods exempt from official controls at border
+                control posts.
+
+
+                - Sufficient evidence must be held in records to demonstrate eligibility
+                for this waiver which must be produced on demand.
+
+
+                - No document status code is required.
+              guidance_chief: This document code is available on CDS only.
+              measure_condition_class: unknown
+              monetary_unit_abbreviation: null
+              requirement: >-
+                Other certificates: Exemption by virtue of Articles 3 and 4 of
+                regulation 2019/2122 (animals intended for scientific purposes, research
+                and diagnostic samples)
+            relationships:
+              measure_condition_components:
+                data: []
+          - id: '20060280'
+            type: measure_condition
+            attributes:
+              action: Import/export not allowed after control
+              action_code: '09'
+              certificate_description: null
+              condition: >-
+                E: The quantity or the price per unit declared, as appropriate, is equal
+                or less than the specified maximum, or presentation of the required
+                document
+              condition_code: E
+              condition_duty_amount: null
+              condition_measurement_unit_code: null
+              condition_measurement_unit_qualifier_code: null
+              condition_monetary_unit_code: null
+              document_code: ''
+              duty_expression: ''
+              guidance_cds: null
+              guidance_chief: null
+              measure_condition_class: negative
+              monetary_unit_abbreviation: null
+              requirement: null
+            relationships:
+              measure_condition_components:
+                data: []
+          - id: c9982ee465cf7dcc85a926f409a91f94
+            type: measure_condition_permutation
+            relationships:
+              measure_conditions:
+                data:
+                  - id: '20060275'
+                    type: measure_condition
+          - id: 4d3b48c99972647c2f067a667703f311
+            type: measure_condition_permutation
+            relationships:
+              measure_conditions:
+                data:
+                  - id: '20060278'
+                    type: measure_condition
+          - id: 2cbaf3625f27ae2236f643c9def204eb
+            type: measure_condition_permutation
+            relationships:
+              measure_conditions:
+                data:
+                  - id: '20060277'
+                    type: measure_condition
+                  - id: '20060276'
+                    type: measure_condition
+          - id: 20098001-n/a
+            type: measure_condition_permutation_group
+            attributes:
+              condition_code: n/a
+            relationships:
+              permutations:
+                data:
+                  - id: c9982ee465cf7dcc85a926f409a91f94
+                    type: measure_condition_permutation
+                  - id: 4d3b48c99972647c2f067a667703f311
+                    type: measure_condition_permutation
+                  - id: 2cbaf3625f27ae2236f643c9def204eb
+                    type: measure_condition_permutation
+          - id: '20098001'
+            type: measure
+            attributes:
+              id: 20098001
+              origin: eu
+              effective_start_date: '2021-01-01T00:00:00.000Z'
+              effective_end_date: null
+              import: true
+              export: false
+              excise: false
+              vat: false
+              reduction_indicator: null
+              meursing: false
+              resolved_duty_expression: ''
+              universal_waiver_applies: false
+            relationships:
+              duty_expression:
+                data:
+                  id: 20098001-duty_expression
+                  type: duty_expression
+              measure_type:
+                data:
+                  id: '410'
+                  type: measure_type
+              legal_acts:
+                data:
+                  - id: C2100270
+                    type: legal_act
+              measure_conditions:
+                data:
+                  - id: '20060275'
+                    type: measure_condition
+                  - id: '20060277'
+                    type: measure_condition
+                  - id: '20060278'
+                    type: measure_condition
+                  - id: '20060281'
+                    type: measure_condition
+                  - id: '20060274'
+                    type: measure_condition
+                  - id: '20060276'
+                    type: measure_condition
+                  - id: '20060279'
+                    type: measure_condition
+                  - id: '20060280'
+                    type: measure_condition
+              measure_condition_permutation_groups:
+                data:
+                  - id: 20098001-n/a
+                    type: measure_condition_permutation_group
+              measure_components:
+                data: []
+              resolved_measure_components:
+                data: []
+              national_measurement_units:
+                data: []
+              geographical_area:
+                data:
+                  id: '1008'
+                  type: geographical_area
+              excluded_countries:
+                data:
+                  - id: AT
+                    type: geographical_area
+                  - id: BE
+                    type: geographical_area
+                  - id: BG
+                    type: geographical_area
+                  - id: CH
+                    type: geographical_area
+                  - id: CY
+                    type: geographical_area
+                  - id: CZ
+                    type: geographical_area
+                  - id: DE
+                    type: geographical_area
+                  - id: DK
+                    type: geographical_area
+                  - id: EE
+                    type: geographical_area
+                  - id: ES
+                    type: geographical_area
+                  - id: EU
+                    type: geographical_area
+                  - id: FI
+                    type: geographical_area
+                  - id: FR
+                    type: geographical_area
+                  - id: GR
+                    type: geographical_area
+                  - id: HR
+                    type: geographical_area
+                  - id: HU
+                    type: geographical_area
+                  - id: IE
+                    type: geographical_area
+                  - id: IS
+                    type: geographical_area
+                  - id: IT
+                    type: geographical_area
+                  - id: LI
+                    type: geographical_area
+                  - id: LT
+                    type: geographical_area
+                  - id: LU
+                    type: geographical_area
+                  - id: LV
+                    type: geographical_area
+                  - id: MT
+                    type: geographical_area
+                  - id: NL
+                    type: geographical_area
+                  - id: 'NO'
+                    type: geographical_area
+                  - id: PL
+                    type: geographical_area
+                  - id: PT
+                    type: geographical_area
+                  - id: RO
+                    type: geographical_area
+                  - id: SE
+                    type: geographical_area
+                  - id: SI
+                    type: geographical_area
+                  - id: SK
+                    type: geographical_area
+              footnotes:
+                data:
+                  - id: CD624
+                    type: footnote
+                  - id: CD686
+                    type: footnote
+                  - id: CD737
+                    type: footnote
+              order_number:
+                data: null
+            meta:
+              duty_calculator:
+                source: uk
+                scheme_code: null
+          - id: '1011'
+            type: geographical_area
+            attributes:
+              id: '1011'
+              description: ERGA OMNES
+              geographical_area_id: '1011'
+            relationships:
+              children_geographical_areas:
+                data:
+                  - id: AD
+                    type: geographical_area
+          - id: '28267'
+            type: heading
+            attributes:
+              goods_nomenclature_item_id: '0208000000'
+              description: Other meat and edible meat offal, fresh, chilled or frozen
+              formatted_description: Other meat and edible meat offal, fresh, chilled or frozen
+              description_plain: Other meat and edible meat offal, fresh, chilled or frozen
+          - id: '28275'
+            type: commodity
+            attributes:
+              producline_suffix: '80'
+              description: Other
+              number_indents: 1
+              goods_nomenclature_item_id: '0208900000'
+              formatted_description: Other
+              description_plain: Other
 
     QuotaSearch:
       description: |
@@ -1966,7 +2475,7 @@ components:
           description: The `id` of the definition. It may be used to uniquely identify a definition.
         data:type:
           type: string
-          description: the type of object this is, e.g. `definition`
+          description: the type of object, i.e. `definition`
         data:attributes:
           description: The definition's attributes, as a [referenced definition object](/reference.html#referenceddefinition "see referenced definition object")
           $ref: '#/components/schemas/ReferencedDefinition'
@@ -2077,7 +2586,7 @@ components:
           description: The `id` of the additional_code. It may be used to uniquely identify an additional_code. For additional_codes, this value is `attributes:code`.
         data:type:
           type: string
-          description: the type of object this is, e.g. `additional_code`
+          description: the type of object, i.e. `additional_code`
         data:attributes:
           description: The additional_code's attributes, as a [referenced additional_code object](/reference.html#referencedadditional_code "see referenced additional_code object")
           $ref: '#/components/schemas/ReferencedAdditionalCode'
@@ -2146,7 +2655,7 @@ components:
           description: The `id` of the additional_code_type. It may be used to uniquely identify an additional_code_type.
         data:type:
           type: string
-          description: the type of object this is, e.g. `additional_code_type`
+          description: the type of object, i.e. `additional_code_type`
         data:attributes:
           description: The additional_code_type's attributes, as a [referenced additional_code_type object](/reference.html#referencedadditional_code_type "see referenced additional_code_type object")
           $ref: '#/components/schemas/ReferencedAdditionalCodeType'
@@ -2172,7 +2681,7 @@ components:
           description: The unique `id` of the certificate. This value is equal to `attributes:certificate_type_code + attributes:certificate_code`.
         data:type:
           type: string
-          description: the type of object this is, e.g. `certificate`
+          description: the type of object, i.e. `certificate`
         data:attributes:
           description: The certificate's attributes, as a [referenced certificate object](/reference.html#referencedcertificate "see referenced certificate object")
           $ref: '#/components/schemas/ReferencedCertificate'
@@ -2203,7 +2712,7 @@ components:
           description: The `id` of the certificate. It may be used to uniquely identify a certificate. For certificates, this value is `attributes:certificate_type_code + attributes:certificate_code`.
         data:type:
           type: string
-          description: the type of object this is, e.g. `certificate`
+          description: the type of object, i.e. `certificate`
         data:attributes:
           description: The certificate's attributes, as a [referenced certificate object](/reference.html#referencedcertificate "see referenced certificate object")
           $ref: '#/components/schemas/ReferencedCertificate'
@@ -2273,7 +2782,7 @@ components:
           description: The `id` of the certificate_type. It may be used to uniquely identify an certificate_type.
         data:type:
           type: string
-          description: the type of object this is, e.g. `certificate_type`
+          description: the type of object, i.e. `certificate_type`
         data:attributes:
           description: The certificate_type's attributes, as a [referenced certificate_type object](/reference.html#referencedcertificate_type "see referenced certificate_type object")
           $ref: '#/components/schemas/ReferencedCertificateType'
@@ -2300,7 +2809,7 @@ components:
           description: The unique `id` of the measure_type.
         data:type:
           type: string
-          description: the type of object this is, e.g. `measure_type`
+          description: the type of object, i.e. `measure_type`
         data:attributes:
           description: The measure_type's attributes, as a [referenced measure_type object](/reference.html#referencedmeasuretype "see referenced measure_type object")
           $ref: '#/components/schemas/ReferencedMeasureType'
@@ -2454,7 +2963,7 @@ components:
           description: The `id` of the footnote. It may be used to uniquely identify a footnote. For footnotes, this value is `attributes:code`.
         data:type:
           type: string
-          description: the type of object this is, e.g. `footnote`
+          description: the type of object, i.e. `footnote`
         data:attributes:
           description: The footnote's attributes, as a [referenced footnote object](/reference.html#referencedfootnote "see referenced footnote object")
           $ref: '#/components/schemas/ReferencedFootnote'
@@ -2528,7 +3037,7 @@ components:
           description: The `id` of the footnote_type. It may be used to uniquely identify an footnote_type.
         data:type:
           type: string
-          description: the type of object this is, e.g. `footnote_type`
+          description: the type of object, i.e. `footnote_type`
         data:attributes:
           description: The footnote_type's attributes, as a [referenced footnote_type object](/reference.html#referencedfootnote_type "see referenced footnote_type object")
           $ref: '#/components/schemas/ReferencedFootnoteType'
@@ -2557,7 +3066,7 @@ components:
           description: The `id` of the chemical. It may be used to uniquely identify a chemical.
         data:type:
           type: string
-          description: The type of object this is, e.g. `chemical`
+          description: the type of object, i.e. `chemical`
         data:attributes:
           description: The chemical's attributes, as a [referenced chemical object](/reference.html#referencedchemical "see referenced chemical object")
           $ref: '#/components/schemas/ReferencedChemical'
@@ -2617,7 +3126,7 @@ components:
           description: The `id` of the chemical. It may be used to uniquely identify a chemical.
         data:type:
           type: string
-          description: the type of object this is, e.g. `chemical`
+          description: the type of object, i.e. `chemical`
         data:attributes:
           description: The chemical's attributes, as a [referenced chemical object](/reference.html#referencedchemical "see referenced chemical object")
           $ref: '#/components/schemas/ReferencedChemical'
@@ -2731,7 +3240,7 @@ components:
             total_count: 54
 
     GoodsNomenclatures:
-      description: |
+      description: "Commodity codes"
       type: object
       properties:
         data:id:
@@ -2739,7 +3248,7 @@ components:
           description: the unique `id` of the goods_nomenclature
         data:type:
           type: string
-          description: the type of object this is, e.g. `goods_nomenclature`
+          description: the type of object, i.e. `goods_nomenclature`
         data:attributes:
           description: The goods_nomeclature's attributes, as a [referenced goods_nomenclature object](/reference.html#referencedgoodsnomenclature "see referenced goods_nomenclature object")
           $ref: '#/components/schemas/ReferencedGoodsNomenclature'
@@ -2774,7 +3283,7 @@ components:
             href: /api/v2/commodities/0101210000
 
     SearchReferences:
-      description: |
+      description: "Curated terms and associated headings, subheadings or commodity codes"
       type: object
       properties:
         data:id:
@@ -2782,7 +3291,7 @@ components:
           description: the unique `id` of the search_reference
         data:type:
           type: string
-          description: the type of object this is, e.g. `search_reference`
+          description: the type of object, i.e. `search_reference`
         data:attributes:
           description: The search_reference's attributes, as a [referenced search_reference object](/reference.html#referencedsearchreference "see referenced search_reference object")
           $ref: '#/components/schemas/ReferencedSearchReference'
@@ -2822,7 +3331,7 @@ components:
           description: The `id` of the geographical area. It may be used to uniquely identify a geographical area.
         data:type:
           type: string
-          description: the type of object this is, e.g. `geographical_area`
+          description: the type of object, i.e. `geographical_area`
         data:attributes:
           description: The geographical area's attributes, as a [referenced geographical area object](/reference.html#referencedgeographicalarea "see referenced geographical area object")
           $ref: '#/components/schemas/ReferencedGeographicalArea'
@@ -2877,7 +3386,7 @@ components:
       properties:
         id:
           type: integer
-          description: The `id` of the section. It may be used to uniquely identify a section and request it's section_note from the API.
+          description: The `id` of the section. It may be used to uniquely identify a section and request its section_note from the API.
         title:
           type: string
           description: The `title` of the section.
@@ -3078,7 +3587,7 @@ components:
           description: The `formatted_description` of the commodity, which may be suitable for presentation to the end user.
         goods_nomenclature_item_id:
           type: string
-          description: The `goods_nomenclature_item_id` of the commodity.
+          description: The `goods_nomenclature_item_id` of the commodity (i.e. the 10-digit commodity code)
         meursing_code:
           type: boolean
           description: Whether this commodity is `meursing_code`.
@@ -3140,6 +3649,88 @@ components:
         excise: false
         vat: false
         reduction_indicator: null
+
+    ReferencedMeasureCondition:
+      description: A measure condition object referenced elsewhere.
+      type: object
+      properties:
+        id:
+          type: string
+          description: The `id` of the measure condition.
+        type:
+          type: string
+          description: the type of object, i.e. `measure_condition`
+        action:
+          type: string
+          description: The measure action code description - see [Measure actions](#get-measure-actions) for examples
+        action_code:
+          type: string
+          description: The measure action code - see [Measure actions](#get-measure-actions) for examples
+        certificate_description:
+          type: string
+          description: where the condition requires a document code, this is the description of that certifcate / document (inclusive of waivers); omits the certificate type description
+        condition:
+          type: string
+          description: condition code description - see [Measure condition codes](#get-measure-condition-codes) for examples
+        condition_code:
+          type: string
+          description: condition code - see [Measure condition codes](#get-measure-condition-codes) for examples
+        condition_duty_amount:
+          type: string
+          description: duty threshold, if required (e.g. for Entry Price System) or weight / volume threshold
+        condition_measurement_unit_code:
+          type: string
+          description: duty threshold or weight / volume measurement unit
+        condition_measurement_unit_qualifier_code:
+          type: string
+          description: duty threshold or weight / volume measurement qualifier unit
+        condition_monetary_unit_code:
+          type: string
+          description: condition monetary unit code
+        document_code:
+          type: string
+          description: the 4-character document code, if required
+        duty_expression:
+          type: string
+          description: combination of any measure condition components (if present)
+        guidance_cds:
+          type: string
+          description: Appendix 5a guidance for data entry in CDS
+        guidance_chief:
+          type: string
+          description: Guidance for data entry in CHIEF
+        measure_condition_class:
+          type: string
+          description: "Class of condition: document or exemption or threshold"
+        monetary_unit_abbreviation:
+          type: string
+          description: Abbreviation of monetary unit
+        requirement:
+          type: string
+          description: Either the document code or the threshold requirement
+      example:
+        id: '20060275'
+        type: measure_condition
+        attributes:
+          action: Import/export allowed after control
+          action_code: "29"
+          certificate_description: "Common Health Entry Document ..."
+          condition: "B: Presentation of a certificate/licence/document"
+          condition_code: "B"
+          condition_duty_amount: null
+          condition_measurement_unit_code: null
+          condition_measurement_unit_qualifier_code: null
+          condition_monetary_unit_code: null
+          document_code: "N853"
+          duty_expression: ""
+          guidance_cds: "Enter GBCHDyyyy. and the reference number of the CHED-P."
+          guidance_chief: "Enter GBCHDyyyy. and the reference number of the CHED-P."
+          measure_condition_class: document
+          monetary_unit_abbreviation: null
+          requirement: "UN/EDIFACT certificates: Common Health Entry Document ..."
+        relationships:
+          measure_condition_components:
+            data: []
 
     ReferencedAdditionalCode:
       description: |
@@ -3509,7 +4100,7 @@ components:
           description: The unique `id` of the quota_order_number.
         data:type:
           type: string
-          description: the type of object this is, e.g. `quota_order_number`
+          description: the type of object, i.e. `quota_order_number`
         data:attributes:
           description: The quota_order_number's attributes, as a [referenced quota_order_number object](/reference.html#referencedquotaordernumber "see referenced quota_order_number object")
           $ref: '#/components/schemas/ReferencedQuotaOrderNumber'
@@ -3757,3 +4348,64 @@ components:
         heading: "39.21-39.22"
         description: "3921: Other plates, sheets, film, foil and strip, of plastics\n\n3922: Baths, shower-baths, wash-basins, bidets, lavatory pans, seats and covers, flushing cisterns and similar sanitary ware, of plastics"
         rule: "A change from any other heading  - CTH;\nor\nMaximum of non-originating materials - MaxNOM 50% (EXW).{{EXW}}{{CTH}}"
+
+    MeasureConditionPermutationGroup:
+      description: A group of measure condition permutations that represent the correct way of interpreting the Boolean relationships between the measure conditions associated with a measure.
+      type: object
+      properties:
+        data:id:
+          type: string
+          description: "A unique 'id' for the measure condition permutation group, formed of two components: the unique ID of the referencing measure and the measure condition code applied to the referenced measure conditions. Where the value of this second component is 'n/a', this indicates that a 'complex measure' is being referenced with multiple condition code groups."
+        data:type:
+          type: string
+          description: the type of object, i.e. `measure_condition_permutation_group`
+        data:attributes:condition_code:
+          type: string
+          description: "the condition code referenced in the permutation, or 'n/a' if multiple condition codes are referenced."
+        data:relationships:permutations:
+          type: array
+          description: A collection of [measure condition permutation objects](/reference.html#measureconditionpermutation "see measure condition permutation object")
+          items:
+            $ref: '#/components/schemas/MeasureConditionPermutation'
+      example:
+        id: "20098001-n/a"
+        type: "measure_condition_permutation_group"
+        attributes:
+          condition_code: "n/a"
+        relationships:
+          permutations:
+            data:
+            - id: c9982ee465cf7dcc85a926f409a91f94
+              type: measure_condition_permutation
+            - id: 4d3b48c99972647c2f067a667703f311
+              type: measure_condition_permutation
+            - id: 2cbaf3625f27ae2236f643c9def204eb
+              type: measure_condition_permutation
+
+    MeasureConditionPermutation:
+      description: Contains references to one or two measure conditions. Where two conditions are referenced, this indicates that there is a requirement for the trader to fulfil both of the noted conditions, for example both supply a waiver and to not exceed a weight or volume threshold.
+      type: object
+      properties:
+        data:id:
+          type: string
+          description: "A unique 'guid' for the measure condition permutation"
+        data:type:
+          type: string
+          description: the type of object, i.e. `measure_condition_permutation`
+        data:relationships:measure_conditions:
+          type: array
+          description: A collection of referenced measure condition objects
+          items:
+            $ref: '#/components/schemas/ReferencedMeasureCondition'
+      example:
+        id: "2cbaf3625f27ae2236f643c9def204eb"
+        type: "measure_condition_permutation"
+        relationships:
+          measure_conditions:
+            data:
+            - id: "20060277"
+              type: "measure_condition"
+            - id: "20060276"
+              type: "measure_condition"
+
+

--- a/source/v2/openapi.yaml
+++ b/source/v2/openapi.yaml
@@ -1789,7 +1789,7 @@ components:
             description: Frogs' legs
             number_indents: 2
             goods_nomenclature_item_id: '0208907000'
-            bti_url: >-
+            bti_url: |-
               https://www.gov.uk/guidance/check-what-youll-need-to-get-a-legally-binding-decision-on-a-commodity-code
             formatted_description: Frogs' legs
             description_plain: Frogs' legs
@@ -1861,7 +1861,7 @@ components:
             type: footnote
             attributes:
               code: TN701
-              description: >-
+              description: |-
                 According to the Council Regulation (EU) No 692/2014 (OJ L183, p. 9) it
                 shall be prohibited to import into European Union goods originating in
                 Crimea or Sevastopol.<br>The prohibition shall not apply in respect of:
@@ -1878,7 +1878,7 @@ components:
                 issued in accordance with Regulation (EU) No 978/2012 and Regulation
                 (EU) No 374/2014 or in accordance with the EU-Ukraine Association
                 Agreement.
-              formatted_description: >-
+              formatted_description: |-
                 According to the Council Regulation (EU) No 692/2014 (OJ L183, p. 9) it
                 shall be prohibited to import into European Union goods originating in
                 Crimea or Sevastopol.<br>The prohibition shall not apply in respect of:
@@ -1928,7 +1928,7 @@ components:
             attributes:
               action: Import/export allowed after control
               action_code: '29'
-              certificate_description: >-
+              certificate_description: |-
                 UN/EDIFACT certificates: Common Health Entry Document for Products
                 (CHED-P) (as set out in Part 2, Section B of Annex II to Commission
                 Implementing Regulation (EU) 2019/1715 (OJ L 261)) as transposed into UK
@@ -1941,7 +1941,7 @@ components:
               condition_monetary_unit_code: null
               document_code: N853
               duty_expression: ''
-              guidance_cds: >-
+              guidance_cds: |-
                 - Enter GBCHDyyyy. and the reference number of the CHED-P.
 
 
@@ -1966,7 +1966,7 @@ components:
                 applies to) this entry'>LE</abbr>, <abbr title='Lodged previously - part
                 use (applies to this and other entries)'>LP</abbr>, <abbr
                 title='Ex-heading goods for which the document does not apply'>XX</abbr>
-              guidance_chief: >-
+              guidance_chief: |-
                 - Use [status
                 code](https://www.gov.uk/government/publications/uk-trade-tariff-document-status-codes-for-harmonised-declarations/uk-trade-tariff-document-status-codes-for-harmonised-declarations)
                 <abbr title='Document attached - exhausted by (or only applies to) this
@@ -1981,7 +1981,7 @@ components:
                 as appropriate.
               measure_condition_class: document
               monetary_unit_abbreviation: null
-              requirement: >-
+              requirement: |-
                 UN/EDIFACT certificates: UN/EDIFACT certificates: Common Health Entry
                 Document for Products (CHED-P) (as set out in Part 2, Section B of Annex
                 II to Commission Implementing Regulation (EU) 2019/1715 (OJ L 261)) as
@@ -1994,7 +1994,7 @@ components:
             attributes:
               action: Import/export allowed after control
               action_code: '29'
-              certificate_description: >-
+              certificate_description: |-
                 Exemption by virtue of Article 7 of Commission Delegated Regulation
                 2019/2122 (Goods which form part of passengers' personal luggage and are
                 intended for personal consumption or use)
@@ -2006,7 +2006,7 @@ components:
               condition_monetary_unit_code: null
               document_code: Y058
               duty_expression: ''
-              guidance_cds: >-
+              guidance_cds: |-
                 - Complete the statement: 'Exempt personal consignment' in the Document
                 Identifier (Second Component).
 
@@ -2028,7 +2028,7 @@ components:
               guidance_chief: This document code is available on CDS only.
               measure_condition_class: exemption
               monetary_unit_abbreviation: null
-              requirement: >-
+              requirement: |-
                 Particular provisions: Exemption by virtue of Article 7 of Commission
                 Delegated Regulation 2019/2122 (Goods which form part of passengers'
                 personal luggage and are intended for personal consumption or use)
@@ -2040,7 +2040,7 @@ components:
             attributes:
               action: Import/export allowed after control
               action_code: '29'
-              certificate_description: >-
+              certificate_description: |-
                 Exemption by virtue of Articles 3 and 4 of regulation 2019/2122 (animals
                 intended for scientific purposes, research and diagnostic samples)
               condition: 'B: Presentation of a certificate/licence/document'
@@ -2051,7 +2051,7 @@ components:
               condition_monetary_unit_code: null
               document_code: C084
               duty_expression: ''
-              guidance_cds: >-
+              guidance_cds: |-
                 - Complete the statement 'regulation 2019/2122 exempt'.
 
 
@@ -2069,7 +2069,7 @@ components:
               guidance_chief: This document code is available on CDS only.
               measure_condition_class: unknown
               monetary_unit_abbreviation: null
-              requirement: >-
+              requirement: |-
                 Other certificates: Exemption by virtue of Articles 3 and 4 of
                 regulation 2019/2122 (animals intended for scientific purposes, research
                 and diagnostic samples)
@@ -2103,12 +2103,12 @@ components:
             attributes:
               action: Import/export allowed after control
               action_code: '29'
-              certificate_description: >-
+              certificate_description: |-
                 UN/EDIFACT certificates: Common Health Entry Document for Products
                 (CHED-P) (as set out in Part 2, Section B of Annex II to Commission
                 Implementing Regulation (EU) 2019/1715 (OJ L 261)) as transposed into UK
                 Law.
-              condition: >-
+              condition: |-
                 E: The quantity or the price per unit declared, as appropriate, is equal
                 or less than the specified maximum, or presentation of the required
                 document
@@ -2119,7 +2119,7 @@ components:
               condition_monetary_unit_code: null
               document_code: N853
               duty_expression: ''
-              guidance_cds: >-
+              guidance_cds: |-
                 - Enter GBCHDyyyy. and the reference number of the CHED-P.
 
 
@@ -2144,7 +2144,7 @@ components:
                 applies to) this entry'>LE</abbr>, <abbr title='Lodged previously - part
                 use (applies to this and other entries)'>LP</abbr>, <abbr
                 title='Ex-heading goods for which the document does not apply'>XX</abbr>
-              guidance_chief: >-
+              guidance_chief: |-
                 - Use [status
                 code](https://www.gov.uk/government/publications/uk-trade-tariff-document-status-codes-for-harmonised-declarations/uk-trade-tariff-document-status-codes-for-harmonised-declarations)
                 <abbr title='Document attached - exhausted by (or only applies to) this
@@ -2159,7 +2159,7 @@ components:
                 as appropriate.
               measure_condition_class: document
               monetary_unit_abbreviation: null
-              requirement: >-
+              requirement: |-
                 UN/EDIFACT certificates: UN/EDIFACT certificates: Common Health Entry
                 Document for Products (CHED-P) (as set out in Part 2, Section B of Annex
                 II to Commission Implementing Regulation (EU) 2019/1715 (OJ L 261)) as
@@ -2173,7 +2173,7 @@ components:
               action: Import/export allowed after control
               action_code: '29'
               certificate_description: null
-              condition: >-
+              condition: |-
                 E: The quantity or the price per unit declared, as appropriate, is equal
                 or less than the specified maximum, or presentation of the required
                 document
@@ -2197,10 +2197,10 @@ components:
             attributes:
               action: Import/export allowed after control
               action_code: '29'
-              certificate_description: >-
+              certificate_description: |-
                 Exemption by virtue of Articles 3 and 4 of regulation 2019/2122 (animals
                 intended for scientific purposes, research and diagnostic samples)
-              condition: >-
+              condition: |-
                 E: The quantity or the price per unit declared, as appropriate, is equal
                 or less than the specified maximum, or presentation of the required
                 document
@@ -2211,7 +2211,7 @@ components:
               condition_monetary_unit_code: null
               document_code: C084
               duty_expression: ''
-              guidance_cds: >-
+              guidance_cds: |-
                 - Complete the statement 'regulation 2019/2122 exempt'.
 
 
@@ -2229,7 +2229,7 @@ components:
               guidance_chief: This document code is available on CDS only.
               measure_condition_class: unknown
               monetary_unit_abbreviation: null
-              requirement: >-
+              requirement: |-
                 Other certificates: Exemption by virtue of Articles 3 and 4 of
                 regulation 2019/2122 (animals intended for scientific purposes, research
                 and diagnostic samples)
@@ -2242,7 +2242,7 @@ components:
               action: Import/export not allowed after control
               action_code: '09'
               certificate_description: null
-              condition: >-
+              condition: |-
                 E: The quantity or the price per unit declared, as appropriate, is equal
                 or less than the specified maximum, or presentation of the required
                 document


### PR DESCRIPTION
### Jira link

[HOTT-1891](https://transformuk.atlassian.net/browse/HOTT-1891)

### What?

I have added/removed/altered:

Line # | After | What’s changed & why
-- | -- | --
21 | 1  summary: Retrieves all sections of the Tariff. | Just a better explanation
1328 | Remove the apostrophe in the word it’s (becomes its, which is correct).This is repeated in a number of places on the API docs. | Remove the apostrophe in the word it’s (becomes its, which is correct)
1331 | Changes e.g. to i.e. | Better English
1785 | New example | Includes permutations
3658 | New section for ReferencedMeasureCondition | Needed for the permutations objects (below)
4357 | New sections for:MeasureConditionPermutationGroupMeasureConditionPermutation | Primary requirement


