### PR TITLE
HOTT-2393: Cleanup old redirect behaviour

### DIFF
--- a/source/beta/openapi.yaml
+++ b/source/beta/openapi.yaml
@@ -266,9 +266,6 @@ components:
                 type: facet_filter_statistic
               - id: 8a34fc49e7461bf91bb00b4527081f31
                 type: facet_filter_statistic
-        meta:
-          redirect: false
-          redirect_to:
         included:
         - id: '27623'
           type: ancestor


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2393

### What?

I have added/removed/altered:

- [x] Removed references to redirects

### Why?

I am doing this because:

- This behaviour has been replaced by the direct hit relationship
- I've not included the direct relationship here because this is for
internal use
