### PR TITLE
HOTT-2886: Added subheadings documentation

### DIFF
--- a/source/v2/openapi.yaml
+++ b/source/v2/openapi.yaml
@@ -1827,6 +1827,141 @@ components:
             position: 1
             section_note: "* 1\\. Any reference in this section to a particular genus or species of an animal..."
 
+    Subheading:
+      description: |
+        A subheading in the tariff.
+
+        A subheading (or heading) describes products in more details.
+      type: object
+      properties:
+        data:id:
+          type: string
+          description: The `id` of the subheading. It may be used to uniquely identify a subheading.
+        data:type:
+          type: string
+          description: the type of object, i.e. `subheading`
+        data:attributes:
+          description: The subheading's attributes, as a [referenced subheading object](/reference.html#referencedsubheading "see referenced subheading object")
+          $ref: '#/components/schemas/ReferencedSubheading'
+        data:relationships:
+          type: object
+          description: |
+            Zero, one or many [referenced section objects](/reference.html#referencedsection "see referenced section object"),
+            [chapter](/reference.html#referencedchapter "see referenced chapter object")
+            or [referenced footnote objects](/reference.html#referencedfootnote "see referenced footnote object") that are related to this subheading.
+            May include parent objects.
+        included:
+          type: array
+          description: |
+            Zero, one or many [referenced chapter](/reference.html#referencedchapter "see referenced chapter object") objects,
+            [referenced guide](/reference.html#referencedguide "see referenced guide object") objects,
+            or [referenced commodity](/reference.html#referencedheadingcommodity "see referenced heading commodity object") objects.
+          items:
+            type: object
+      example:
+        data:
+          id: "94057"
+          type: subheading
+          attributes:
+            goods_nomenclature_item_id: '0102291000'
+            description: Of a weight not exceeding 80 kg
+            formatted_description: "Of a weight not exceeding 80 kg"
+          relationships:
+            footnotes:
+              data:
+              - id: "701"
+                type: footnote
+            section:
+              data:
+                id: "1"
+                type: section
+            chapter:
+              data:
+                id: "27809"
+                type: chapter
+            commodities:
+              data:
+              - id: "27811"
+                type: commodity
+              - id: "104276"
+                type: commodity
+              - id: "104254"
+                type: commodity
+        included:
+        - id: "27809"
+          type: chapter
+          attributes:
+            goods_nomenclature_item_id: "0200000000"
+            description: "MEAT AND EDIBLE MEAT OFFAL"
+            formatted_description: "Meat and edible meat offal"
+            chapter_note: "* 1\\.This chapter does not cover:\r\n  * (a) products of the kinds described in headings 0201 to 0208 or 0210, unfit or unsuitable for human consumption; ... "
+          relationships:
+            guides:
+              data:
+              - id: "23"
+                type: guide
+        - id: "23"
+          type: guide
+          attributes:
+            title: Classification of goods
+            url: https://www.gov.uk/government/collections/classification-of-goods
+        - id: "27811"
+          type: commodity
+          attributes:
+            description: "Carcases and half-carcases"
+            number_indents: 1
+            goods_nomenclature_item_id: "0201100000"
+            leaf: false
+            goods_nomenclature_sid: 27811,
+            formatted_description: "Carcases and half-carcases"
+            description_plain: "Carcases and half-carcases"
+            producline_suffix: "80"
+            parent_sid: null
+          relationships:
+            overview_measures:
+              data:
+              - id: "2982599"
+                type: measure
+        - id: "2982599"
+          type: measure
+          attributes:
+            id: 2982599
+            vat: false
+          relationships:
+            duty_expression:
+              data:
+                id: "2982599-duty_expression"
+                type: duty_expression
+            measure_type:
+              data:
+                id: "109"
+                type: measure_type
+        - id: "2982599-duty_expression"
+          type: duty_expression
+          attributes:
+            base: "p/st"
+            formatted_base: "\u003cabbr title='Number of items'\u003ep/st\u003c/abbr\u003e"
+        - id: "109"
+          type: measure_type
+          attributes:
+            description: "Supplementary unit"
+            national: null
+            measure_type_series_id: null
+            id: "109"
+        - id: "701"
+          type: footnote
+          attributes:
+            code: "TN701"
+            description: "According to  the Council Regulation (EU) No 692/2014sons, entity or body..."
+            formatted_description: "According to  the Council Regulation (EU) No 692/2014 (OJ L183, p. 9) it shall be..."
+        - id: "1"
+          type: section
+          attributes:
+            numeral: "I"
+            title: "Live animals; animal products"
+            position: 1
+            section_note: "* 1\\. Any reference in this section to a particular genus or species of an animal..."
+
     Commodity:
       description: |
         Commodities are headings or subheadings.

--- a/source/v2/openapi.yaml
+++ b/source/v2/openapi.yaml
@@ -260,21 +260,19 @@ paths:
           source: |-
             curl -X GET https://www.trade-tariff.service.gov.uk/api/v2/headings/0101
 
-  /subheadings/{subheading_id}-{productline_suffix}:
+  /subheadings/{goods_nomenclature_item_id}-{productline_suffix}:
     get:
       summary: Retrieves a subheading
       description: >
-        This endpoint returns a single subheading. The subheading_id parameter is used to uniquely identify the subheading, and it is the first ten digits of the subheading's goods_nomenclature_item_id. The productline_suffix parameter is a two-digit code that further describes the product line of the subheading.
-        <p>The `subheading_id` should be a zero-padded string of six (10) digits.</p>
-        <p>The `productline_suffix` should be a zero-padded string of two (2) digits.</p>
+        This resource is uniquely identified by a combination of goods_nomenclature_item_id and productline_suffix.
       tags:
       - Subheadings
       parameters:
-      - name: 'subheading_id'
+      - name: 'goods_nomenclature_item_id'
         in: path
         required: true
         description: |
-          The subheading_id of the subheading to be retrieved, e.g. the first ten (10) digits of the goods_nomenclature_item_id. This should be a zero-padded string of ten (10) digits.
+          The goods_nomenclature_item_id of the subheading to be retrieved, e.g. the first ten (10) digits of the goods_nomenclature_item_id. This should be a zero-padded string of ten (10) digits.
         schema:
           type: string
           minimum: 10

--- a/source/v2/openapi.yaml
+++ b/source/v2/openapi.yaml
@@ -260,6 +260,53 @@ paths:
           source: |-
             curl -X GET https://www.trade-tariff.service.gov.uk/api/v2/headings/0101
 
+  /subheadings/{subheading_id}-{productline_suffix}:
+    get:
+      summary: Retrieves a subheading
+      description: >
+        This endpoint returns a single subheading. The subheading_id parameter is used to uniquely identify the subheading, and it is the first ten digits of the subheading's goods_nomenclature_item_id. The productline_suffix parameter is a two-digit code that further describes the product line of the subheading.
+        <p>The `subheading_id` should be a zero-padded string of six (10) digits.</p>
+        <p>The `productline_suffix` should be a zero-padded string of two (2) digits.</p>
+      tags:
+      - Subheadings
+      parameters:
+      - name: 'subheading_id'
+        in: path
+        required: true
+        description: |
+          The subheading_id of the subheading to be retrieved, e.g. the first ten (10) digits of the goods_nomenclature_item_id. This should be a zero-padded string of ten (10) digits.
+        schema:
+          type: string
+          minimum: 10
+          maximum: 10
+          example: "0102291000"
+      - name: 'productline_suffix'
+        in: path
+        description: The two-digit product line suffix of the subheading to retrieve
+        required: true
+        schema:
+          type: string
+          minimum: 2
+          maximum: 2
+        example: "80"
+      responses:
+        200:
+          description: The requested subheading was found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Subheading'
+              example:
+                $ref: '#/components/schemas/Subheading/example'
+        404:
+          description: The requested subheading was not found.
+        5XX:
+          description: Unexpected error.
+      x-code-samples:
+        /api/v2/chapters:
+          lang: shell
+          source: |-
+            curl -X GET https://www.trade-tariff.service.gov.uk/api/v2/subheadings/0102291000-80
 
   /commodities/{id}:
     get:


### PR DESCRIPTION
### Jira link

[HOTT-<TODO>](https://transformuk.atlassian.net/browse/HOTT-2886)

### What?

I have added/removed/altered:

- [ ] Added subheadings documentation

### Why?

I am doing this because:

- The documentation for subheadings didn't exist and needed to be added

### Have you? (optional)

- [ ] Reviewed the documentation with the relevant stakeholders
- [ ] Followed the documentation through yourself to check it is correct

<img width="1371" alt="Screenshot 2023-03-20 at 14 24 58" src="https://user-images.githubusercontent.com/12201130/226369897-88c67798-f7ee-4b49-a505-e6d4fcacd36a.png">

