### PR TITLE
HOTT-2965-2916: Updated support email and added undocumented message

### DIFF
--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -70,6 +70,8 @@ Changes to the API are documented on the [Latest News](/news.html) page
 
 They are also available as a feed to subscribe to at the [API News feed](/feed.xml)
 
+The APIs contain a number of undocumented features which are used for internal Online Trade Tariff operations. Please contact the support email address below before using undocumented features.
+
 ## Security and compliance
 
 ### Reporting vulnerabilities
@@ -93,7 +95,7 @@ to the latest versions for security and feature enhancements.
 ## Support
 
 If you experience any issues or have questions regarding GOV.UK Trade Tariff API
-please contact [support@hmrc.gov.uk](mailto:support@hmrc.gov.uk?subject=Trade%20Tariff%20API)
+please contact [hmrc-trade-tariff-support-g@digital.hmrc.gov.uk](mailto:hmrc-trade-tariff-support-g@digital.hmrc.gov.uk?subject=Trade%20Tariff%20API)
 
 [HTTPS]: https://en.wikipedia.org/wiki/HTTPS
 [JSON]: https://en.wikipedia.org/wiki/JSON


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2965
https://transformuk.atlassian.net/browse/HOTT-2916

### What?

I have added/removed/altered:

- [ ] Updated support email and added undocumented message

### Why?

I am doing this because:

- API Docs were outdated

<img width="1560" alt="Screenshot 2023-03-30 at 09 59 14" src="https://user-images.githubusercontent.com/12201130/228786285-535328f5-2ae3-4cce-8fdf-a43623d88072.png">
