### PR TITLE
BAU: Fix ci workflow, prod should be behind gate

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,4 +82,4 @@ workflows:
           filters:
             branches:
               only: [main]
-          requires: [build]
+          requires: [build, hold_deploy_production]


### PR DESCRIPTION
### Jira link

[HOTT-2786](https://transformuk.atlassian.net/browse/HOTT-2786)

### What?

I have added/removed/altered:

- Fixed job ordering, production deploy needed an extra `requires`

### Why?

I am doing this because:

- Prod deploys should be gated here
