### PR TITLE
HOTT-3098: Added syntax highlighting to code samples

### DIFF
--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -27,3 +27,11 @@ table {
 img {
     max-width: 90% !important;
 }
+
+.technical-documentation {
+    line-height: 0.8em;
+
+    code {
+        font-size: 0.65em;
+    }
+}

--- a/templates/heading_code_samples.dot
+++ b/templates/heading_code_samples.dot
@@ -1,2 +1,4 @@
 
 **Example Request**
+
+

--- a/templates/heading_example_responses.dot
+++ b/templates/heading_example_responses.dot
@@ -1,2 +1,4 @@
 
 **Example Response**
+
+


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-3098

### What?

I have added/removed/altered:

- [ ] Added syntax highlighting to code samples

### Why?

I am doing this because:

- these changes will make code samples easier to read

Before
<img width="1724" alt="Screenshot 2023-05-02 at 16 42 18" src="https://user-images.githubusercontent.com/12201130/235716390-47ff4d27-918b-490a-bc81-10d5815ed7c4.png">

After
<img width="1599" alt="Screenshot 2023-05-02 at 16 32 50" src="https://user-images.githubusercontent.com/12201130/235716038-ededa9eb-1548-4425-b889-a318d3be83aa.png">

