### PR TITLE
HOTT-3606: Adds measurement unit qualifiers to api docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,11 @@ To update the Trade Tariff API documentation, you may follow this general workfl
 - If the changes involve the API specification itself, edit the `source/v2/openapi.yaml` file. This file is used to build the HTML file `build/reference.html`.
 
   - edit `source/v2/openapi.yaml`
-  - ```
+
+  - ```shell
     make serve
     ```
+
   - manually (re)load [http://localhost:4567](http://localhost:4567) in a browser when the Middleman server (re)starts
 
 - It is also useful to add an entry in the `NEWS.yml` file, this information will be published on the Latest News page for users viewing these docs. It will also be added to the `/feed.xml` atom feed for anyone subscribing for updates.
@@ -46,23 +48,24 @@ As we release new versions of the API, we will continue to support older version
 
 In order to do this, some modifications to the default Middleman templates and options are required:
 
-1.  create a new `openapi.yaml` file for the new API version and a directory in which to store it
+1. create a new `openapi.yaml` file for the new API version and a directory in which to store it
 
 ```
-$ mkdir v2
-$ touch v2/openapi.yaml
+mkdir v2
+touch v2/openapi.yaml
 ```
 
-2.  edit `config/tech-docs.yml` - add new link in the header for old reference file, i.e.;
+2. edit `config/tech-docs.yml` - add new link in the header for old reference file, i.e.;
 
 ```
  Reference: /reference.html
 ```
 
-3.  edit `Makefile`
+3. edit `Makefile`
 
 - add new task to generate old reference file
 - rename previous reference file, add "-v1" (or whatever the old version number is) to the output filename
+
   ```
   ./generate.js source/v1/openapi.yaml source/reference-v1.html.md.erb
   ```
@@ -113,12 +116,12 @@ The example above is rendered into HTML:
 
 The `openapi.yaml` file makes use of [`$ref`](https://swagger.io/specification/#documentStructure) to refer to connected parts of the specification. In the example above, [`$ref`](https://swagger.io/specification/#documentStructure) is used to refer to the schema and example response in another part of the document.
 
-Information on `$ref`: https://swagger.io/specification/#documentStructure
+Information on `$ref`: <https://swagger.io/specification/#documentStructure>
 
 ### Links
 
-- OAS 3.0 Specification (https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#oasDocument)
-- Swagger, upon which OAS is based (https://swagger.io/specification/)
+- OAS 3.0 Specification (<https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#oasDocument>)
+- Swagger, upon which OAS is based (<https://swagger.io/specification/>)
 
 ## Running documentation locally
 
@@ -126,13 +129,13 @@ Information on `$ref`: https://swagger.io/specification/#documentStructure
 
 Manual build and deploy is not necessary if automated deploy is used.
 
-1.  Build the documentation
+1. Build the documentation
 
 ```
 bundle exec middleman build --clean
 ```
 
-2.  Push to prod
+2. Push to prod
 
 ```
 cf push tariff-api-production
@@ -159,19 +162,19 @@ Type the following to start the server:
 make serve
 ```
 
-You should now be able to view a live preview at http://localhost:4567.
+You should now be able to view a live preview at <http://localhost:4567>.
 
 ## Publishing documentation
 
 ### Development
 
-Any changes pushed to GitHub on a branch (eg, a Pull Request) will be deployed 
+Any changes pushed to GitHub on a branch (eg, a Pull Request) will be deployed
 automatically to the [Development URL](https://tariff-api-dev.london.cloudapps.digital)
 
 ### Production
 
-Any changes to `main` on GitHub will be deployed automatically to our published docs 
-at [api.trade-tariff.service.gov.uk](https://api.trade-tariff.service.gov.uk) 
+Any changes to `main` on GitHub will be deployed automatically to our published docs
+at [api.trade-tariff.service.gov.uk](https://api.trade-tariff.service.gov.uk)
 
 ## License
 

--- a/source/reference-data.html.md
+++ b/source/reference-data.html.md
@@ -10,7 +10,7 @@ Measure type series are used to group measure types, and therefore measures,
 according to their use in the declaration process. The sequence corresponds to the
 order against which border systems, such as CDS, should validate a declaration.
 
-For example, if a declaration does not meet the requirements of measure type series `A` (prohibitions), 
+For example, if a declaration does not meet the requirements of measure type series `A` (prohibitions),
 then measures pertaining to the remaining series are not addressed.
 
 Measure type series are largely static, i.e. change to the list provided below is extremely rare.
@@ -37,7 +37,6 @@ Measure type series are largely static, i.e. change to the list provided below i
 |S|Supplementary amount|
 |Z|Archived measure type|
 
-
 ## Measure types
 
 Measures are grouped according to their nature into measure types. Measure types
@@ -50,7 +49,7 @@ types in use, access the [measure types API](https://www.trade-tariff.service.go
 
 ### Prohibition-type measures (series A)
 
-If an import or export declaration does not meet the requirements of the applied prohibition-type controls, 
+If an import or export declaration does not meet the requirements of the applied prohibition-type controls,
 then a trade will not be permitted to proceed.
 
 |ID|Description|Import&nbsp;/&nbsp;export|
@@ -66,7 +65,7 @@ Restrictive controls permit a trade to proceed under certain conditions, e.g.
 
 - provision of a certificate or licence in the form of an electronic document code;
 - submission of exemption to a measure, via an exemption-type document code;
-- adherence to threshold controls (e.g. weight or volume) 
+- adherence to threshold controls (e.g. weight or volume)
 
 |ID|Description|Import&nbsp;/&nbsp;export|
 |-|-|-|
@@ -256,7 +255,6 @@ Excise only
 |-|-|-|
 |306|Excises|Import|Q|
 
-
 ### Supplementary amount-type measures (series S)
 
 Quotas and securities required on the import of poultry (Northern Ireland tariff only)
@@ -272,10 +270,9 @@ Quotas and securities required on the import of poultry (Northern Ireland tariff
 |657|Reduced security based on representative price|Import|S|
 |658|Reduced additional duty based on CIF price|Import|S|
 
-
 ## Measure action codes
 
-Measure action codes illustrate how CDS (and other border systems) will act in 
+Measure action codes illustrate how CDS (and other border systems) will act in
 response to measure conditions being met or not met.
 
 |Action code|Description|
@@ -334,3 +331,81 @@ A condition code identifies what sort of condition is to be fulfilled in order f
 |W|Washington Convention|
 |Y|Other conditions|
 |Z|Presentation of more than one certificate|
+
+## Measurement units
+
+|Code|Description|
+|:----|:----|
+|ASV|%vol|
+|CCT|Carrying capacity in metric tonnes|
+|CEN|Hundred items|
+|CTM|Carats (one metric carat = 2 x 10<sup>-4</sup>kg)|
+|DAP|Decatonne, corrected according to polarisation|
+|DHS|Kilogram of dihydrostreptomycin|
+|DTN|Hectokilogram|
+|EUR|Euro (used for statistical surveillance)|
+|FC1|Factor|
+|GFI|Gram of fissile isotopes|
+|GP1|Gross Production|
+|GRM|Gram|
+|GRT|Gross tonnage|
+|HLT|Hectolitre|
+|HMT|Hectometre|
+|KAC|Kilogram net of acesulfame potassium|
+|KCC|Kilogram of choline chloride|
+|KCL|Tonne of potassium chloride|
+|KGM|Kilogram|
+|KLT|1000 litres|
+|KMA|Kilogram of methylamines|
+|KMT|Kilometre|
+|KNI|Kilogram of nitrogen|
+|KNS|Kilogram of hydrogen peroxide|
+|KPH|Kilogram of potassium hydroxide (caustic potash)|
+|KPO|Kilogram of potassium oxide|
+|KPP|Kilogram of diphosphorus pentaoxide|
+|KSD|Kilogram of substance 90¬†% dry|
+|KSH|Kilogram of sodium hydroxide (caustic soda)|
+|KUR|Kilogram of uranium|
+|KW1|Kilowatt Hour|
+|LPA|Litre pure (100%) alcohol|
+|LTR|Litre|
+|MCG|Microgram|
+|MCL|Microlitre|
+|MGM|Milligram|
+|MIL|1000 items|
+|MLT|Millilitre|
+|MPR|1000 pairs (used for statistical surveillance)|
+|MTK|Square metre|
+|MTQ|Cubic meter|
+|MTR|Metre|
+|MWH|1000 kilowatt hours|
+|NAR|Number of items|
+|NCL|Number of cells|
+|NPR|Number of pairs|
+|RET|Retail Price|
+|TJO|Terajoule (gross calorific value)|
+|TNE|Tonne|
+|WAT|Number of Watt|
+
+## Measurement unit qualifiers
+
+|Code|Description|
+|:----|:----|:----|
+|A|total alcohol|
+|B|per flask|
+|C|1 000|
+|D|per 1% by weight of sucrose or extractable sugar|
+|E|of drained net weight|
+|F|of common wheat|
+|G|, gross|
+|I|of biodiesel content|
+|J|of fuel content (usually in form of tallow, stearin, paraffin wax or other waxes, including the wick)|
+|K|of bioethanol content|
+|L|of live weight|
+|M|net of dry matter|
+|P|of lactic matter|
+|R|of the standard quality|
+|S|of sugar with a yield in white sugar of 92%|
+|T|of dry lactic matter|
+|X|per hectolitre|
+|Z|per 1% by weight of sucrose|


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-3606

### What?

I have added/removed/altered:

- [x] Added measurement unit qualifiers to reference data page

### Why?

I am doing this because:

- This is helpful to users
