### PR TITLE
BAU: Add links to sites for dev, staging and production for easier review

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ is provided by the [GOV.UK Tech Docs Template][tech-docs-template] and through
 the use of a [fork][forked-widdershins] of [widdershins][widdershins] to
 convert the [`openapi.yaml`][tariff-openapi] to Markdown.
 
-These docs are deployed under to the following URLs:
+These docs are deployed to the following URLs:
 
 - *Development* - https://api.dev.trade-tariff.service.gov.uk
 - *Staging* - https://api.staging.trade-tariff.service.gov.uk

--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@ is provided by the [GOV.UK Tech Docs Template][tech-docs-template] and through
 the use of a [fork][forked-widdershins] of [widdershins][widdershins] to
 convert the [`openapi.yaml`][tariff-openapi] to Markdown.
 
+These docs are deployed under to the following URLs:
+
+- *Development* - https://api.dev.trade-tariff.service.gov.uk
+- *Staging* - https://api.staging.trade-tariff.service.gov.uk
+- *Production* - https://api.trade-tariff.service.gov.uk
+
 ## Updating content
 
 To update content of this site, modify the files under `source` directory, i.e., `source/v2/openapi.yaml`.


### PR DESCRIPTION
### Jira link

BAU

### What?

I have added/removed/altered:

- [x] Added links to each environment's docs site

### Why?

I am doing this because:

- I end up looking this up in the Cloudfront CDN configuration and this is just quicker and easier
