### PR TITLE
BAU: Tidy 404 message

### DIFF
--- a/source/v2/openapi.yaml
+++ b/source/v2/openapi.yaml
@@ -1406,8 +1406,6 @@ paths:
           description: "200 Success."
         400:
           description: "Bad request. For example type is not spot, monthly or average."
-        404:
-          description: "Not found. There are no Exchange rate periods for the requested year."
         5XX:
           description: Unexpected error.
       x-code-samples:


### PR DESCRIPTION
### Jira link

BAU

### What?

I have added/removed/altered:

- [x] Removes 404 messages for exchange rates

### Why?

I am doing this because:

- These do not return 404 for an empty list of exchange rates or periods
