### PR TITLE
BAU: Remove Manual Prod Gate

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,24 +114,18 @@ workflows:
           context: trade-tariff
           <<: *filter-main
 
-      - promote-to-production?:
-          type: approval
-          <<: *filter-main
-
       - deploy:
           name: deploy-prod-paas
           context: trade-tariff-bot-aws-production
           environment: production
-          <<: *filter-not-main
+          <<: *filter-main
           requires:
             - build-prod
-            - promote-to-production?
 
       - deploy:
           name: deploy-prod
           context: trade-tariff-terraform-aws-production
           environment: "382373577178"
-          <<: *filter-not-main
+          <<: *filter-main
           requires:
             - build-prod
-            - promote-to-production?


### PR DESCRIPTION
### What?

I have added/removed/altered:

- Removed the manual gate to production deployments.

### Why?

I am doing this because:

- The job filters/requires were broken, leading to true ci/cd, which is what we want anyway. This didn't cause us any problems so we proved we didn't need that gate.
