### PR TITLE
BAU: Stop Deploying to PaaS Dev & Staging

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,14 +69,6 @@ workflows:
           <<: *filter-not-main
 
       - deploy:
-          name: deploy-dev-paas
-          context: trade-tariff-bot-aws-development
-          environment: development
-          <<: *filter-not-main
-          requires:
-            - build-dev
-
-      - deploy:
           name: deploy-dev
           context: trade-tariff-terraform-aws-development
           environment: "844815912454"
@@ -90,14 +82,6 @@ workflows:
           name: build-staging
           context: trade-tariff
           <<: *filter-main
-
-      - deploy:
-          name: deploy-staging-paas
-          context: trade-tariff-bot-aws-staging
-          environment: staging
-          <<: *filter-main
-          requires:
-            - build-staging
 
       - deploy:
           name: deploy-staging


### PR DESCRIPTION
### What?

I have added/removed/altered:

- Stopped API docs from deploying to PaaS buckets.

### Why?

I am doing this because:

- Dev and staging are now not on PaaS.