### PR TITLE
HOTT-5108 Add diagrams

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,6 +34,9 @@ jobs:
     steps:
       - checkout
       - run:
+          name: Install graphviz
+          command: sudo apt-get update && sudo apt-get install -yy graphviz
+      - run:
           name: Build static site
           command: make html
       - persist_to_workspace:

--- a/.editorconfig
+++ b/.editorconfig
@@ -8,3 +8,11 @@ charset = utf-8
 end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
+
+[*.dot]
+indent_size = 4
+indent_style = space
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 requirements:
 	npm install
 	bundle install
+	which dot || (echo "Please install Graphviz via your package manager" && exit 1)
 
 clean:
 	rm -rf build

--- a/README.md
+++ b/README.md
@@ -155,6 +155,8 @@ Setting up the documentation requires Ruby and Node. Run the following to instal
 make requirements
 ```
 
+**Note:** You will also need to manually install Graphviz via your package manager
+
 ### Preview changes
 
 Whilst writing documentation we can run a middleman server to preview how the

--- a/config.rb
+++ b/config.rb
@@ -4,3 +4,20 @@ GovukTechDocs.configure(self)
 
 activate :relative_assets
 set :relative_links, true
+
+helpers do
+  def graphviz(graph_file = nil, &block)
+    if block_given?
+      data = capture_html(&block)
+    elsif graph_file
+      data = File.read("source/graphviz/#{graph_file.sub(/\.dot$/, '')}.dot")
+    else
+      return
+    end
+
+    out, err, status = Open3.capture3( "dot -Tsvg", stdin_data: data )
+    svg = out.gsub( /.*<svg/m, "<svg" ).gsub( /\n/m, "").html_safe
+
+    concat_content(svg.html_safe)
+  end
+end

--- a/source/graphviz/category-assessment.dot
+++ b/source/graphviz/category-assessment.dot
@@ -1,0 +1,22 @@
+digraph {
+    rankdir="LR"
+    fontname="Arial,sans-serif"
+    node [fontname="Arial,sans-serif"]
+    edge [fontname="Arial,sans-serif"]
+
+    node [shape=diamond,style=filled,color=lightgrey];
+    "Excluded\nGeo Areas";
+    "Exemptions";
+
+    node [shape=ellipse,style=unfilled,color=black];
+    "Category\nAssessment" -> "Exemptions"
+    "Exemptions" -> "Certificate"
+    "Exemptions" -> "AdditionalCode"
+    "Exemptions" -> "Certificate 2"
+    "Category\nAssessment" -> "Geographical\nArea"
+    "Category\nAssessment" -> "Excluded\nGeo Areas"
+    "Excluded\nGeo Areas" -> "Geographical\nArea 2"
+    "Excluded\nGeo Areas" -> "Geographical\nArea 3"
+    "Category\nAssessment" -> "Theme"
+    "Category\nAssessment" -> "Measure"
+}

--- a/source/graphviz/category-assessment.dot
+++ b/source/graphviz/category-assessment.dot
@@ -11,7 +11,7 @@ digraph {
     node [shape=ellipse,style=unfilled,color=black];
     "Category\nAssessment" -> "Exemptions"
     "Exemptions" -> "Certificate"
-    "Exemptions" -> "AdditionalCode"
+    "Exemptions" -> "Additional Code"
     "Exemptions" -> "Certificate 2"
     "Category\nAssessment" -> "Geographical\nArea"
     "Category\nAssessment" -> "Excluded\nGeo Areas"

--- a/source/graphviz/declarations-A.dot
+++ b/source/graphviz/declarations-A.dot
@@ -1,0 +1,33 @@
+digraph {
+    rankdir="LR"
+    fontname="Arial,sans-serif"
+    node [fontname="Arial,sans-serif"]
+    edge [fontname="Arial,sans-serif"]
+
+    node [shape=diamond,style=filled,color=lightgrey];
+    "Applicable\nCAs";
+    "Descendants\nCAs";
+    "Measures";
+    "Ancestors";
+    "Descendants";
+
+    node [shape=ellipse,style=unfilled,color=black];
+    "Goods\nNomenclature" -> "Applicable\nCAs"
+    "Goods\nNomenclature" -> "Measures"
+    "Applicable\nCAs" -> "Category\nAssessment"
+    "Category\nAssessment 2" -> "Measure 2"
+    "Applicable\nCAs" -> "Category\nAssessment 2"
+    "Category\nAssessment" -> "Measure"
+    "Goods\nNomenclature" -> "Descendants\nCAs"
+    "Descendants\nCAs" -> "Category\nAssessment 3"
+    "Category\nAssessment 3" -> "Measure 3"
+    "Goods\nNomenclature" -> "Ancestors"
+    "Ancestors" -> "Chapter GN"
+    "Chapter GN" -> "Measure 2"
+    "Ancestors" -> "Heading GN"
+    "Goods\nNomenclature" -> "Descendants"
+    "Descendants" -> "Commodity GN 1"
+    "Descendants" -> "Commodity GN 2"
+    "Commodity GN 2" -> "Measure 3"
+    "Measures" -> "Measure"
+}

--- a/source/graphviz/measure.dot
+++ b/source/graphviz/measure.dot
@@ -1,0 +1,19 @@
+digraph {
+    rankdir="LR"
+    fontname="Arial,sans-serif"
+    node [fontname="Arial,sans-serif"]
+    edge [fontname="Arial,sans-serif"]
+
+    node [shape=diamond,style=filled,color=lightgrey];
+    "Measure\nConditions"
+
+    node [shape=ellipse,style=unfilled,color=black];
+    "Measure" -> "Measure\nType"
+    "Measure" -> "Additional\nCode"
+    "Measure" -> "Footnote"
+    "Measure" -> "Measure\nConditions"
+    "Measure\nConditions" -> "Measure\nCondition 1"
+    "Measure\nCondition 1" -> "Certificate"
+    "Measure\nConditions" -> "Measure\nCondition 2"
+    "Measure\nCondition 2" -> "Certificate 2"
+}

--- a/source/v2/greenlanes-openapi.yaml
+++ b/source/v2/greenlanes-openapi.yaml
@@ -185,7 +185,10 @@ components:
 
   schemas:
     GoodsNomenclature:
-      description: A goods_nomenclature object
+      description: |
+        A goods_nomenclature object
+
+        <% graphviz 'declarations-A' %>
       type: object
       properties:
         id:
@@ -354,7 +357,10 @@ components:
                 goods originating in Crimea or Sevastopol.\n..."
 
     CategoryAssessment:
-      description: A CategoryAssessment for the requested GoodsNomenclature
+      description: |
+        A CategoryAssessment for the requested GoodsNomenclature
+
+        <% graphviz 'category-assessment' %>
       type: object
       properties:
         id:
@@ -568,8 +574,11 @@ components:
             formatted_description: "Shanghai Huayi Group Corp. Ltd Double Coin Group (Jiang Su) Tyre Co., Ltd"
 
     Measure:
-      description: A Measure object which generates this Category Assessment.
       type: object
+      description: |
+        A Measure object which generates this Category Assessment.
+
+        <% graphviz 'measure' %>
       properties:
         id:
           type: string


### PR DESCRIPTION
### Jira link

HOTT-5108

### What?

I have added/removed/altered:

- [x] Added diagram for GoodsNomenclature entity tree
- [x] Added diagram for CategoryAssessment entity tree
- [x] Added diagram for Measure entity tree
- [x] Extended pipeline to install new dependencies

### Why?

I am doing this because:

- It makes it easier for our partners to understand the APIs they will need to consume

### Have you? (optional)

- [x] Reviewed the documentation with the relevant stakeholders
- [x] Followed the documentation through yourself to check it is correct

### Screenshots

![image](https://github.com/trade-tariff/trade-tariff-api-docs/assets/10818/37a42c25-c8e8-46d4-b51b-71285085b9ac)

