### PR TITLE
HOTT-5298 Separated out the 'next version' of the docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ api:
 	./generate.js source/v2/openapi.yaml source/reference.html.md.erb
 	./generate.js source/beta/openapi.yaml source/reference-beta.html.md.erb
 	./generate.js source/v2/greenlanes-openapi.yaml source/green-lanes.html.md.erb
+	./generate.js source/v2/greenlanes-old-openapi.yaml source/green-lanes-old.html.md.erb
 
 html: requirements clean api
 	bundle exec rake build

--- a/data/green_lanes_changes.yml
+++ b/data/green_lanes_changes.yml
@@ -21,9 +21,9 @@
 
     Also corrects the api example when filtering by goods origin.
 
-- date: 2024-03-11
+- date: 2024-03-12
   content: |
-    Revised and extended API structure
+    Revised and extended API structure - added as a separate 'next' page for now until the API is updated to reflect it
 
     * Reverted to a relationship to separate Theme entity in place of `Category.theme`
     * Added `descendant_category_assessments` to the GoodsNomenclature API

--- a/source/v2/greenlanes-old-openapi.yaml
+++ b/source/v2/greenlanes-old-openapi.yaml
@@ -32,10 +32,6 @@ info:
       </strong>
     </div>
 
-    ### Previous version
-
-    Earlier docs for the current [API implementation](/green-lanes-old.html)
-
     ## Authentication
 
     Access to these APIs will be restricted initially whilst they are in development. Approved partners requiring access should contact the Online Trade Tariff team.
@@ -45,35 +41,6 @@ info:
     ```
     Authorization: Token <SUPPLIED TOKEN>
     ```
-
-    ## Latest changes
-
-    _These changes can be subscribed to at the [Atom (RSS) feed](/green-lanes.xml)_
-
-    <% changes = data.green_lanes_changes.sort_by(&:date).reverse %>
-    <% latest = changes.shift %>
-
-    ### <%= latest.date.strftime('%-d %B %Y') %>
-    <%= simple_format latest.content %>
-
-    <% unless changes.length == 0 %>
-    <details class="govuk-details">
-      <summary class="govuk-details__summary">
-        <span class="govuk-details__summary-text">
-          Previous changes
-        </span>
-      </summary>
-      <div class="govuk-details__text">
-        <% changes.each do |change| %>
-          <h3 id="change-<%= change.date.strftime('%Y-%m-%d') %>" class="anchored-heading">
-            <%= change.date.strftime '%d %b %Y' %>
-          </h3>
-
-          <%= simple_format change.content %>
-        <% end %>
-      </div>
-    </details>
-    <% end %>
 
 paths:
   /green_lanes/category_assessments:
@@ -195,10 +162,7 @@ components:
 
   schemas:
     GoodsNomenclature:
-      description: |
-        A goods_nomenclature object
-
-        <% graphviz 'goods-nomenclature' %>
+      description: A goods_nomenclature object
       type: object
       properties:
         id:
@@ -207,10 +171,6 @@ components:
         goods_nomenclature_item_id:
           type: string
           description: The `goods_nomenclature_item_id` of this Goods Nomenclature
-        parent_sid:
-          type: string
-          description: The goods_nomenclature_sid of the Goods Nomenclature this GoodsNomenclature sits directly below in the Tariff
-          nullable: true
         description:
           type: string
           description: The `description` of the goods nomenclature
@@ -234,35 +194,9 @@ components:
           description: A list of applicable Category Assessments for this Goods Nomenclature
           items:
             $ref: '#/components/schemas/CategoryAssessment'
-        descendant_category_assessments:
-          type: array
-          description: |
-            A list of Category Assessments which apply only to some descendants,
-            so require further classification to determine their applicability
-          items:
-            $ref: '#/components/schemas/CategoryAssessment'
-        ancestors:
-          type: array
-          description: |
-            List of GoodsNomenclatures above the requested Goods Nomenclature in
-            the Tariff, ordered by Chapter first
-          items:
-            $ref: '#/components/schemas/ReferencedGoodsNomenclature'
-        descendants:
-          description: |
-            List of GoodsNomenclatures below the requested one in the Tariff,
-            ordered by Goods Nomenclature Item Id
-          items:
-            $ref: '#/components/schemas/ReferencedGoodsNomenclature'
-        measures:
-          type: array
-          description: The measures directly against this GoodsNomenclature
-          items:
-            $ref: '#/components/scheme/Measure'
       required:
         - id
         - goods_nomenclature_item_id
-        - parent_sid
         - description
         - number_indents
         - productline_suffix
@@ -270,65 +204,28 @@ components:
         - validity_end_date
       example:
         data:
-          id: "106662"
+          id: "70361"
           type: goods_nomenclature
           attributes:
-            goods_nomenclature_item_id: "2404120000"
-            parent_sid: "106659"
-            description: Other, containing nicotine
-            number_indents: 2
+            goods_nomenclature_item_id: "0702000007"
+            description: Cherry tomatoes
+            number_indents: 1
             productline_suffix: "80"
-            validity_start_date: "2022-01-01T00:00:00.000Z"
+            validity_start_date: "1999-01-01T00:00:00.000Z"
             validity_end_date: null
           relationships:
             applicable_category_assessments:
-              data:
-                - id: 123456cd
-                  type: category_assessment
-            descendant_category_assessments:
               data:
                 - id: abcd1234
                   type: category_assessment
                 - id: c5678def
                   type: category_assessment
-            ancestors:
-              data:
-                - id: "35246"
-                  type: goods_nomenclature
-                - id: "106659"
-                  type: goods_nomenclature
-            descendants:
-              data:
-                - id: "106676"
-                  type: goods_nomenclature
-                - id: "107156"
-                  type: goods_nomenclature
-            measures:
-              data: []
         included:
-          - id: 123456cd
-            type: category_assessments
-            relationships:
-              geographical_area:
-                data:
-                  id: "1011"
-                  type: geographical_area
-              excluded_geographical_areas:
-                data: []
-              theme:
-                data:
-                  id: "1.1"
-                  type: theme
-              exemptions:
-                data:
-                  - id: Y069
-                    type: certificate
-              measures:
-                data:
-                  - id: "3871194"
-                    type: measure
           - id: abcd1234
             type: category_assessments
+            attributes:
+              category: 1
+              theme: 1.1 Sanctions
             relationships:
               geographical_area:
                 data:
@@ -336,25 +233,17 @@ components:
                   type: geographical_area
               excluded_geographical_areas:
                 data: []
-              theme:
-                data:
-                  id: "2.1"
-                  type: theme
               exemptions:
                 data:
-                  - id: L135
+                  - id: D005
                     type: certificate
-                  - id: "3200"
+                  - id: C371
                     type: additional_code
-              measures:
-                - data:
-                    - id: "3871192"
-                      type: measure
-                - data:
-                    - id: "3871247"
-                      type: measure
           - id: c5678def
             type: category_assessment
+            attributes:
+              category: 1
+              theme: 1.1 Sanctions
             relationships:
               geographical_area:
                 data:
@@ -362,219 +251,76 @@ components:
                   type: geographical_area
               excluded_geographical_areas:
                 data: []
-              theme:
-                data:
-                  id: "2.1"
-                  type: theme
-              exemptions:
-                - id: "3200"
-                  type: additional_code
-                - id: "3249"
-                  type: additional_code
+              exemptions: []
               measures:
-                - data:
-                    - id: "3871193"
-                      type: measure
-                    - id: "3871248"
-                      type: measure
+                data:
+                  - id: "20098001"
+                    type: measure
           - id: "1011"
             type: geographical_area
             attributes:
               description: ERGA OMNES
               geographical_area_id: "1011"
-          - id: "1.1"
-            type: theme
-            attributes:
-              theme: Sanctions
-              category: 1
-          - id: "2.1"
-            type: theme
-            attributes:
-              theme: Drug precursors
-              category: 2
-          - id: L135
+          - id: D005
             type: certificate
             attributes:
-              certificate_type_code: L
-              certificate_code: "135"
-              description: "Import authorisation (precursors) issued by the competent authorities of the Member State where the importer is established"
-          - id: "3200"
+              certificate_type_code: D
+              certificate_code: "005"
+              description: "Commercial invoice within the framework of undertakings"
+          - id: C371
             type: additional_code
             attributes:
-              additional_code_type_id: "3"
-              additional_code: "200"
-              code: "3200"
-              description: "Mixtures of scheduled substances listed in the Annex to Regulation (EC) No 111/2005 that can be used for the illicit manufacture of narcotic drugs or psychotropic substances"
-              formatted_description: "Mixtures of scheduled substances listed in the Annex to Regulation (EC) No 111/2005 that can be used for the illicit manufacture of narcotic drugs or psychotropic substances"
-          - id: Y069
-            type: certificate
-            attributes:
-              certificate_type_code: Y
-              certificate_code: "069"
-              description: "Goods not consigned from Iran"
-          - id: "3871194"
+              additional_code_type_id: C
+              additional_code: "371"
+              code: C371
+              description: "Shanghai Huayi Group Corp. Ltd Double Coin Group (Jiang Su) Tyre Co., Ltd"
+              formatted_description: "Shanghai Huayi Group Corp. Ltd Double Coin Group (Jiang Su) Tyre Co., Ltd"
+          - id: "20098001"
             type: measure
             attributes:
-              goods_nomenclature_item_id: "2404120000"
-              goods_nomenclature_sid: "106662"
-              effective_start_date: "2022-01-01T00:00:00.000Z"
+              effective_start_date: "2021-01-01T00:00:00.000Z"
               effective_end_date: null
             relationships:
+              goods_nomenclature:
+              data:
+                id: "30256"
+                type: goods_nomenclature
               measure_type:
                 data:
-                  id: "714"
-                  type: measure_type
-          - id: "3871192"
-            type: measure
-            attributes:
-              goods_nomenclature_item_id: "2404120010"
-              goods_nomenclature_sid: "106676"
-              effective_start_date: "2022-01-01T00:00:00.000Z"
-              effective_end_date: null
-            relationships:
-              measure_type:
-                data:
-                  id: "475"
+                  id: "410"
                   type: measure_type
               footnotes:
                 data:
-                  - id: CD437
+                  - id: CD624
                     type: footnote
-          - id: "3871193"
-            type: measure
-            attributes:
-              goods_nomenclature_item_id: "2404120010"
-              goods_nomenclature_sid: "106676"
-              effective_start_date: "2022-01-01T00:00:00.000Z"
-              effective_end_date: null
-            relationships:
-              measure_type:
-                data:
-                  id: "475"
-                  type: measure_type
-              footnotes:
-                data:
-                  - id: TM135
-                    type: footnote
-          - id: "3871247"
-            type: measure
-            attributes:
-              goods_nomenclature_item_id: "2404120090"
-              goods_nomenclature_sid: "107156"
-              effective_start_date: "2022-01-01T00:00:00.000Z"
-              effective_end_date: null
-            relationships:
-              measure_type:
-                data:
-                  id: "475"
-                  type: measure_type
-              footnotes:
-                data:
-                  - id: CD437
-                    type: footnote
-                  - id: TM135
-                    type: footnote
-          - id: "3871248"
-            type: measure
-            attributes:
-              effective_start_date: "2022-01-01T00:00:00.000Z"
-              effective_end_date: null
-            relationships:
-              measure_type:
-                data:
-                  id: "475"
-                  type: measure_type
-              footnotes:
-                data:
-                  - id: TM135
-                    type: footnote
-          - id: "35246"
+          - id: "30256"
             type: goods_nomenclature
             attributes:
-              goods_nomenclature_item_id: "2400000000"
-              parent_sid: null
-              description: Tobacco and manufactured tobacco substitutes; products, whether or not containing nicotine, intended for inhalation without combustion; other nicotine containing products intended for the intake of nicotine into the human body
+              goods_nomenclature_item_id: "0702000000"
+              description: Tomatoes, fresh or chilled
               number_indents: 0
               productline_suffix: "80"
-              validity_start_date: "1971-12-31T00:00:00.000Z"
+              validity_start_date: "1999-01-01T00:00:00.000Z"
               validity_end_date: null
-          - id: "106659"
-            type: goods_nomenclature
-            attributes:
-              goods_nomenclature_item_id: "2404000000"
-              parent_sid: 35246
-              description: Products containing tobacco, reconstituted tobacco, nicotine, or tobacco or nicotine substitutes, intended for inhalation without combustion; other nicotine containing products intended for the intake of nicotine into the human body
-              number_indents: 0
-              productline_suffix: "80"
-              validity_start_date: "2022-01-01T00:00:00.000Z"
-              validity_end_date: null
-          - id: "106676"
-            type: goods_nomenclature
-            attributes:
-              goods_nomenclature_item_id: "2404120010"
-              parent_sid: 106662
-              description: Cartridges and refills, filled, for electronic cigarettes, preparations for use in cartridges and refills for electronic cigarettes
-              number_indents: 3
-              productline_suffix: "80"
-              validity_start_date: "2022-01-01T00:00:00.000Z"
-              validity_end_date: null
-            relationships:
-              measures:
-                data:
-                  - id: "3871192"
-                    type: "measure"
-                  - id: "3871193"
-                    type: "measure"
-          - id: "107156"
-            type: goods_nomenclature
-            attributes:
-              goods_nomenclature_item_id: "2404120090"
-              parent_sid: 106662
-              description: Other
-              number_indents: 3
-              productline_suffix: "80"
-              validity_start_date: "2022-01-01T00:00:00.000Z"
-              validity_end_date: null
-            relationships:
-              measures:
-                data:
-                  - id: "3871247"
-                    type: "measure"
-                  - id: "3871248"
-                    type: "measure"
-          - id: "475"
+          - id: "110"
             type: measure_type
             attributes:
-              description: "Restriction on entry into free circulation"
-              measure_type_series_description: "Entry into free circulation or exportation subject to conditions"
+              description: "Supplementary unit import"
+              measure_type_series_description: "Supplementary unit"
               validity_start_date: "1972-01-01T00:00:00.000Z"
               validity_end_date: null
-              measure_type_series_id: "B"
+              measure_type_series_id: "O"
               trade_movement_code: 0
-          - id: "714"
-            attributes:
-              description: "Import control"
-              measure_type_series_description: "Entry into free circulation or exportation subject to conditions"
-              validity_start_date: "2017-02-01 00:00:00.000"
-              validity_end_date: null
-              measure_type_series_id: "B"
-              trade_movement_code: 0
-          - id: CD437
+          - id: TN701
             type: footnote
             attributes:
-              code: CD437
-              description: "\"Import authorization\" and \"Specific import requirements\" - see Articles 20-25 of Regulation (EC) No 111/05 (OJ L 22) implemented by Regulation (EC) No 2015/1011 (OJ L 162)."
-          - id: TM135
-            type: footnote
-            attributes:
-              code: TM135
-              description: "The surveillance does not apply to mixtures and natural products which contain scheduled substances and which are compounded in such a way that the scheduled substances cannot be easily used or extracted by readily applicable or economically viable means, to medicinal products as defined in point 2 of Article 1 of Directive 2001/83/EC of the European Parliament and of the Council and to veterinary medicinal products as defined in point 2 of Article 1 of Directive 2001/82/EC of the European Parliament and of the Council."
+              code: TN701
+              description: "According to  the Council Regulation (EU) No 692/2014
+                (OJ L183, p. 9) it shall be prohibited to import into European Union
+                goods originating in Crimea or Sevastopol.\n..."
 
     CategoryAssessment:
-      description: |
-        A CategoryAssessment for the requested GoodsNomenclature
-
-        <% graphviz 'category-assessment' %>
+      description: A CategoryAssessment for the requested GoodsNomenclature
       type: object
       properties:
         id:
@@ -585,8 +331,8 @@ components:
           enum: [ 1, 2, 3 ]
           description: The category applicable unless exemption criteria are met
         theme:
-          description: The Green Lanes Theme used as the basis for this Category Assessment
-          $ref: '#/components/scheme/Theme'
+          type: string
+          description: The Green Lanes theme relevant for this Category Assessment
         geographical_area:
           description: The geographical area this Category Assessment applies to
           $ref: '#/components/scheme/GeographicalArea'
@@ -619,6 +365,9 @@ components:
         data:
           id: abcd1234
           type: category_assessment
+          attributes:
+            category: 1
+            theme: 1.1 Sanctions
           relationships:
             geographical_area:
               data:
@@ -626,15 +375,11 @@ components:
                 type: geographical_area
             excluded_geographical_areas:
               data: []
-            theme:
-              data:
-                id: "2.1"
-                type: theme
             exemptions:
               data:
-                - id: L135
+                - id: D005
                   type: certificate
-                - id: "3200"
+                - id: C371
                   type: additional_code
         included:
           - id: "1011"
@@ -642,52 +387,20 @@ components:
             attributes:
               description: ERGA OMNES
               geographical_area_id: "1011"
-          - id: "2.1"
-            type: theme
-            attributes:
-              theme: Drug precursors
-              category: 2
-          - id: L135
+          - id: D005
             type: certificate
             attributes:
-              certificate_type_code: L
-              certificate_code: "135"
-              description: "Import authorisation (precursors) issued by the competent authorities of the Member State where the importer is established"
-          - id: "3200"
+              certificate_type_code: D
+              certificate_code: "005"
+              description: "Commercial invoice within the framework of undertakings"
+          - id: C371
             type: additional_code
             attributes:
-              additional_code_type_id: "3"
-              additional_code: "200"
-              code: "3200"
-              description: "Mixtures of scheduled substances listed in the Annex to Regulation (EC) No 111/2005 that can be used for the illicit manufacture of narcotic drugs or psychotropic substances"
-              formatted_description: "Mixtures of scheduled substances listed in the Annex to Regulation (EC) No 111/2005 that can be used for the illicit manufacture of narcotic drugs or psychotropic substances"
-
-    Theme:
-      description: A Green Lane Theme within the Windsor Framework
-      type: object
-      properties:
-        id:
-          type: string
-          description: The relevant section number for this Green Lanes theme
-        theme:
-          type: string
-          description: Green Lanes Theme
-        category:
-          type: integer
-          minimum: 1
-          maximum: 3
-          description: The green lanes category for the theme in the absence of an exemption
-      required:
-        - id
-        - theme
-        - category
-      example:
-        data:
-          id: "1.1"
-          type: theme
-          attributes:
-            theme: Sanctions
-            category: 1
+              additional_code_type_id: C
+              additional_code: "371"
+              code: C371
+              description: "Shanghai Huayi Group Corp. Ltd Double Coin Group (Jiang Su) Tyre Co., Ltd"
+              formatted_description: "Shanghai Huayi Group Corp. Ltd Double Coin Group (Jiang Su) Tyre Co., Ltd"
 
     GeographicalArea:
       description: A GeographicalArea object
@@ -775,32 +488,22 @@ components:
         - formatted_description
       example:
         data:
-          id: "3200"
+          id: C371
           type: additional_code
           attributes:
-            additional_code_type_id: "3"
-            additional_code: "200"
-            code: "3200"
-            description: "Mixtures of scheduled substances listed in the Annex to Regulation (EC) No 111/2005 that can be used for the illicit manufacture of narcotic drugs or psychotropic substances"
-            formatted_description: "Mixtures of scheduled substances listed in the Annex to Regulation (EC) No 111/2005 that can be used for the illicit manufacture of narcotic drugs or psychotropic substances"
+            additional_code_type_id: C
+            additional_code: "371"
+            code: C371
+            description: "Shanghai Huayi Group Corp. Ltd Double Coin Group (Jiang Su) Tyre Co., Ltd"
+            formatted_description: "Shanghai Huayi Group Corp. Ltd Double Coin Group (Jiang Su) Tyre Co., Ltd"
 
     Measure:
+      description: A Measure object which generates this Category Assessment.
       type: object
-      description: |
-        A Measure object which generates this Category Assessment.
-
-        <% graphviz 'measure' %>
       properties:
         id:
           type: string
           description: The unique identifier for this measure
-        goods_nomenclature_item_id:
-          type: string
-          description: |
-            The item id of the GoodsNomenclature this Measure is against.
-        goods_nomenclature_sid:
-          type: string
-          description: The item id of the GoodsNomenclature this Measure is against
         effective_start_date:
           type: string
           description: The effective start date of the measure.
@@ -818,29 +521,32 @@ components:
           description: The footnotes for this measure
           items:
             $ref: '#/components/scheme/Footnote'
+        goods_nomenclature:
+          description: The goods nomenclature this measure is directly against
+          $ref: '#/components/scheme/ReferencedGoodsNomenclature'
       required:
         - id
-        - goods_nomenclature_item_id
-        - goods_nomenclature_sid
         - effective_start_date
         - effective_end_date
       example:
         data:
-          id: "3871192"
+          id: "20098001"
           type: measure
           attributes:
-            goods_nomenclature_item_id: "2404120010"
-            goods_nomenclature_sid: "106676"
-            effective_start_date: "2022-01-01T00:00:00.000Z"
+            effective_start_date: "2021-01-01T00:00:00.000Z"
             effective_end_date: null
           relationships:
+            goods_nomenclature:
+              data:
+                id: "30256"
+                type: goods_nomenclature
             measure_type:
               data:
-                id: "475"
+                id: "410"
                 type: measure_type
             footnotes:
               data:
-                - id: CD437
+                - id: CD624
                   type: footnote
 
     MeasureType:
@@ -874,14 +580,14 @@ components:
           description: The code of trade movement.
       example:
         data:
-          id: "475"
+          id: "110"
           type: measure_type
           attributes:
-            description: "Restriction on entry into free circulation"
-            measure_type_series_description: "Entry into free circulation or exportation subject to conditions"
+            description: "Supplementary unit import"
+            measure_type_series_description: "Supplementary unit"
             validity_start_date: "1972-01-01T00:00:00.000Z"
             validity_end_date: null
-            measure_type_series_id: "B"
+            measure_type_series_id: "O"
             trade_movement_code: 0
 
     Footnote:
@@ -899,14 +605,16 @@ components:
           description: The `description` for the footnote
       example:
         data:
-          id: CD437
+          id: TN701
           type: footnote
           attributes:
-            code: CD437
-            description: "\"Import authorization\" and \"Specific import requirements\" - see Articles 20-25 of Regulation (EC) No 111/05 (OJ L 22) implemented by Regulation (EC) No 2015/1011 (OJ L 162)."
+            code: TN701
+            description: "According to  the Council Regulation (EU) No 692/2014
+              (OJ L183, p. 9) it shall be prohibited to import into European Union
+              goods originating in Crimea or Sevastopol.\n..."
 
     ReferencedGoodsNomenclature:
-      description: A GoodsNomenclature referenced from either Ancestors or Descendants lists
+      description: A referenced GoodsNomenclature which a measure is against
       type: object
       properties:
         id:
@@ -915,10 +623,6 @@ components:
         goods_nomenclature_item_id:
           type: string
           description: The `goods_nomenclature_item_id` of this Goods Nomenclature
-        parent_sid:
-          type: string
-          description: The goods_nomenclature_sid of the Goods Nomenclature this GoodsNomenclature sits directly below in the Tariff
-          nullable: true
         description:
           type: string
           description: The `description` of the goods nomenclature
@@ -937,16 +641,9 @@ components:
           description: The date this Goods Nomenclature is valid until, null if valid indefinitely
           format: date-time
           nullable: true
-        measures:
-          type: array
-          description: The measures directly against this GoodsNomenclature
-          items:
-            $ref: '#/components/scheme/Measure'
       required:
         - id
         - goods_nomenclature_item_id
-        - goods_nomenclatur_sid
-        - parent_sid
         - description
         - number_indents
         - productline_suffix
@@ -954,23 +651,15 @@ components:
         - validity_end_date
       example:
         data:
-          id: "106659"
+          id: "70361"
           type: goods_nomenclature
           attributes:
-            goods_nomenclature_item_id: "2404000000"
-            parent_sid: "30240"
-            description: Products containing tobacco, reconstituted tobacco, nicotine, or tobacco or nicotine substitutes, intended for inhalation without combustion; other nicotine containing products intended for the intake of nicotine into the human body
+            goods_nomenclature_item_id: "0702000000"
+            description: Tomatoes, fresh or chilled
             number_indents: 0
             productline_suffix: "80"
-            validity_start_date: "2022-01-01T00:00:00.000Z"
+            validity_start_date: "1999-01-01T00:00:00.000Z"
             validity_end_date: null
-          relationships:
-            measures:
-              data:
-                - id: "3871192"
-                  type: "measure"
-                - id: "3871193"
-                  type: "measure"
 
     CategoryAssessmentListing:
       description: Listing of all category assessments
@@ -1015,11 +704,10 @@ components:
         data:
           - id: abcd1234
             type: category_assessment
+            attributes:
+              category: 1
+              theme: 1.1 Sanctions
             relationships:
-              theme:
-                data:
-                  id: "2.1"
-                  type: theme
               geographical_area:
                 data:
                   id: "1011"
@@ -1028,17 +716,16 @@ components:
                 data: []
               exemptions:
                 data:
-                  - id: L135
+                  - id: D005
                     type: certificate
-                  - id: "3200"
+                  - id: C371
                     type: additional_code
           - id: abcd1234
             type: category_assessment
+            attributes:
+              category: 1
+              theme: 1.1 Sanctions
             relationships:
-              theme:
-                data:
-                  id: "1.1"
-                  type: theme
               geographical_area:
                 data:
                   id: "1011"
@@ -1048,32 +735,22 @@ components:
               exemptions:
                 data: []
         included:
-          - id: "1.1"
-            type: theme
-            attributes:
-              theme: Sanctions
-              category: 1
           - id: "1011"
             type: geographical_area
             attributes:
               description: ERGA OMNES
               geographical_area_id: "1011"
-          - id: "2.1"
-            type: theme
-            attributes:
-              theme: Drug precursors
-              category: 2
-          - id: L135
+          - id: D005
             type: certificate
             attributes:
-              certificate_type_code: L
-              certificate_code: "135"
-              description: "Import authorisation (precursors) issued by the competent authorities of the Member State where the importer is established"
-          - id: "3200"
+              certificate_type_code: D
+              certificate_code: "005"
+              description: "Commercial invoice within the framework of undertakings"
+          - id: C371
             type: additional_code
             attributes:
-              additional_code_type_id: "3"
-              additional_code: "200"
-              code: "3200"
-              description: "Mixtures of scheduled substances listed in the Annex to Regulation (EC) No 111/2005 that can be used for the illicit manufacture of narcotic drugs or psychotropic substances"
-              formatted_description: "Mixtures of scheduled substances listed in the Annex to Regulation (EC) No 111/2005 that can be used for the illicit manufacture of narcotic drugs or psychotropic substances"
+              additional_code_type_id: C
+              additional_code: "371"
+              code: C371
+              description: "Shanghai Huayi Group Corp. Ltd Double Coin Group (Jiang Su) Tyre Co., Ltd"
+              formatted_description: "Shanghai Huayi Group Corp. Ltd Double Coin Group (Jiang Su) Tyre Co., Ltd"


### PR DESCRIPTION
### Jira link

HOTT-5298

I have added/removed/altered:

- [x] Split the GL docs into two versions

### Why?

I am doing this because:

- We also want to keep the version which reflects the currently available API