### PR TITLE
GL-288: Document themes API endpoint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 requirements:
 	npm install
 	bundle install
-	which dot || (echo "Please install Graphviz via your package manager" && exit 1)
+	which dot || (echo "Please install Graphviz via your system package manager" && exit 1)
 
 clean:
 	rm -rf build

--- a/README.md
+++ b/README.md
@@ -131,6 +131,10 @@ Information on `$ref`: <https://swagger.io/specification/#documentStructure>
 
 ## Running documentation locally
 
+### Pre Requisite
+
+Graphviz installed in your local environment
+
 ### Manual Build and Deploy
 
 Manual build and deploy is not necessary if automated deploy is used.

--- a/data/green_lanes_changes.yml
+++ b/data/green_lanes_changes.yml
@@ -35,3 +35,9 @@
 - date: 2024-03-12
   content: |
     Added sample API client implementation in Javascript and HTML. Key lines for JSON:API parsing are 19, 20, 73
+
+- date: 2024-04-18
+  content: |
+    Revised Green Lanes API documentation
+
+    * Added Theme API

--- a/source/v2/greenlanes-openapi.yaml
+++ b/source/v2/greenlanes-openapi.yaml
@@ -195,6 +195,29 @@ paths:
             curl -X GET -H "Authorization: Token TOKEN123" https://www.trade-tariff.service.gov.uk/xi/api/v2/green_lanes/goods_nomenclatures/0712909000?as_of=2024-01-01
             curl -X GET -H "Authorization: Token TOKEN123" "https://www.trade-tariff.service.gov.uk/xi/api/v2/green_lanes/goods_nomenclatures/0712909000?filter\[geographical_area_id\]=US"
             curl -X GET -H "Authorization: Token TOKEN123" "https://www.trade-tariff.service.gov.uk/xi/api/v2/green_lanes/goods_nomenclatures/0712909000?as_of=2024-01-01&filter\[geographical_area_id\]=US"
+  /green_lanes/themes:
+    get:
+      summary: Returns a list of all themes
+      description: >
+        Returns a list of the all Green Lane themes within the Windsor Framework
+      tags:
+        - Green Lanes
+      responses:
+        200:
+          description: An array of Themes
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Themes"
+        401:
+          description: Authorization header is missing or contains an invalid token
+        5xx:
+          description: Unexpected error, something went wrong internally
+      x-code-samples:
+        /api/v2/green_lanes/themes:
+          lang: shell
+          source: |-
+            curl -X GET -H "Authorization: Token TOKEN123" https://www.trade-tariff.service.gov.uk/xi/api/v2/green_lanes/themes
 
 components:
   securitySchemes:


### PR DESCRIPTION
### Jira link

[GL-288](https://transformuk.atlassian.net/browse/GL-288)

### What?

I have added/removed/altered:

- [x] Added document for the themes API endpoint 

### Why?

I am doing this because:

- The new theme end point added in to the trade-tariff api

