### PR TITLE
FPO-184: Adds status page reference

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -15,8 +15,8 @@ helpers do
       return
     end
 
-    out, err, status = Open3.capture3( "dot -Tsvg", stdin_data: data )
-    svg = out.gsub( /.*<svg/m, "<svg" ).gsub( /\n/m, "").html_safe
+    out, err, _status = Open3.capture3('dot -Tsvg', stdin_data: data)
+    svg = out.gsub(/.*<svg/m, '<svg').gsub(/\n/m, '').html_safe
 
     concat_content(svg.html_safe)
   end

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -15,6 +15,11 @@ It is accessed via [HTTPS][] and returns data in a [JSON][]
 format. The [reference documentation](reference.html) provides a thorough
 overview of the endpoints and the response format.
 
+The OTT team maintains a status page that indicates the overall health of various
+services including the backend and FPO applications.
+
+This can be reviewed [here][status]
+
 ## What you can do with this API
 
 The data provided by this API is used on [GOV.UK Trade Tariff](https://www.gov.uk/trade-tariff).
@@ -119,3 +124,4 @@ please contact [hmrc-trade-tariff-support-g@digital.hmrc.gov.uk](mailto:hmrc-tra
 
 [HTTPS]: https://en.wikipedia.org/wiki/HTTPS
 [JSON]: https://en.wikipedia.org/wiki/JSON
+[status]: https://status.trade-tariff.service.gov.uk

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -20,6 +20,8 @@ services including the backend and FPO applications.
 
 This can be reviewed [here][status]
 
+For internal documentation on the management of the API, please see the [internal documentation][tech-docs].
+
 ## What you can do with this API
 
 The data provided by this API is used on [GOV.UK Trade Tariff](https://www.gov.uk/trade-tariff).
@@ -125,3 +127,4 @@ please contact [hmrc-trade-tariff-support-g@digital.hmrc.gov.uk](mailto:hmrc-tra
 [HTTPS]: https://en.wikipedia.org/wiki/HTTPS
 [JSON]: https://en.wikipedia.org/wiki/JSON
 [status]: https://status.trade-tariff.service.gov.uk
+[tech-docs]: https://docs.trade-tariff.service.gov.uk


### PR DESCRIPTION
### Jira link

FPO-184

### What?

I have added/removed/altered:

- [x] Added reference to the status page

### Why?

I am doing this because:

- This is required to communicate the availability of the status page to internal/external users
