### PR TITLE
OTT-276: Ensuring the correctness of the schema for the changes endpoint

### DIFF
--- a/source/v2/openapi.yaml
+++ b/source/v2/openapi.yaml
@@ -1205,11 +1205,11 @@ paths:
 
   /changes/{as_of}:
     get:
-      summary: Retrieves a list of goods nomenclature objects that have changed on the given day
+      summary: Retrieves a list of goods nomenclature objects that have changed since the previous day
       description: |
-        Retrieves a list of goods nomenclature objects that have changed on the given day
+        Retrieves a list of goods nomenclature objects that have changed since the previous day
 
-        Note that changes only go back 30 days
+        Note that changes are only available for the previous 30 days up to the current day. Requests for changes outside of these dates will results in an empty set of changes.
       tags:
         - Changes
       parameters:

--- a/source/v2/openapi.yaml
+++ b/source/v2/openapi.yaml
@@ -1202,13 +1202,14 @@ paths:
           lang: shell
           source: |-
             curl -X GET https://www.trade-tariff.service.gov.uk/api/v2/geographical_areas/countries
+
   /changes/{as_of}:
     get:
-      summary: Retrieves a list of goods nomenclature objects that have changed since the previous day
+      summary: Retrieves a list of goods nomenclature objects that have changed on a given day
       description: |
-        Retrieves a list of goods nomenclature objects that have changed since the previous day
+        Retrieves a list of goods nomenclature objects that have changed on a given day
 
-        Changes only go back 30 days
+        Note that changes only go back 30 days
       tags:
         - Changes
       parameters:
@@ -1226,9 +1227,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Change"
-              example:
-                $ref: "#/components/schemas/Change/example"
+                $ref: "#/components/schemas/ChangesResponse"
         5XX:
           description: Unexpected error.
       x-code-samples:
@@ -1236,6 +1235,7 @@ paths:
           lang: shell
           source: |-
             curl -X GET https://www.trade-tariff.service.gov.uk/api/v2/changes/2021-01-01
+
   /rules_of_origin_schemes/{subheading}/{country_code}:
     get:
       summary: Retrieves relevant Rules of Origin schemes and rules
@@ -4283,6 +4283,36 @@ components:
         referenced_class: "Heading"
         productline_suffix: "80"
 
+    ChangesResponse:
+      description: A list of changes to goods nomenclature
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/Change"
+      example:
+        data:
+        - id: "106193"
+          type: "change"
+          attributes:
+            goods_nomenclature_sid: "106193"
+            goods_nomenclature_item_id: "7606129292"
+            productline_suffix: "10"
+            end_line: false
+            change_type: "commodity"
+            change_date: "2021-04-13"
+        
+        - id: "125323"
+          type: "change"
+          attributes:
+            goods_nomenclature_sid: "125323"
+            goods_nomenclature_item_id: "2204109100"
+            productline_suffix: "80"
+            end_line: true
+            change_type: "commodity"
+            change_date: "2021-04-13"
+
     Change:
       description: Indicates a change to a given goods nomenclature.
       type: object
@@ -4297,6 +4327,10 @@ components:
           type: object
           description: The changed goods nomenclature attributes.
           $ref: "#/components/schemas/ChangeAttributes"
+      required:
+        - id
+        - type
+        - attributes
       example:
         id: "106193"
         type: "change"
@@ -4331,6 +4365,13 @@ components:
           type: string
           description: Date of the change.
           format: date
+      required:
+        - goods_nomenclature_sid
+        - goods_nomenclature_item_id
+        - productline_suffix
+        - end_line
+        - change_type
+        - change_date
       example:
         goods_nomenclature_sid: "106193"
         goods_nomenclature_item_id: "7606129292"

--- a/source/v2/openapi.yaml
+++ b/source/v2/openapi.yaml
@@ -1205,9 +1205,9 @@ paths:
 
   /changes/{as_of}:
     get:
-      summary: Retrieves a list of goods nomenclature objects that have changed on a given day
+      summary: Retrieves a list of goods nomenclature objects that have changed on the given day
       description: |
-        Retrieves a list of goods nomenclature objects that have changed on a given day
+        Retrieves a list of goods nomenclature objects that have changed on the given day
 
         Note that changes only go back 30 days
       tags:
@@ -1234,7 +1234,7 @@ paths:
         /api/v2/changes:
           lang: shell
           source: |-
-            curl -X GET https://www.trade-tariff.service.gov.uk/api/v2/changes/2021-01-01
+            curl -X GET https://www.trade-tariff.service.gov.uk/api/v2/changes/2021-04-13
 
   /rules_of_origin_schemes/{subheading}/{country_code}:
     get:
@@ -4291,6 +4291,8 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/Change"
+      required:
+        - data
       example:
         data:
         - id: "106193"


### PR DESCRIPTION

### Jira link

OTT-276

### What?

I have added/removed/altered:

- [x] Updated the changes endpoint response schema to match the json api
- [x] Updated the example accordingly
- [x] Updated the properties to be 'required'

### Why?

I am doing this because:

- A team is attempting to integrate with the API and is finding the documentation confusing as neither the schema or example matches the actual response

