### PR TITLE
OTT-286: Fixing a few more small issues with the openapi spec for /changes

### DIFF
--- a/source/v2/openapi.yaml
+++ b/source/v2/openapi.yaml
@@ -4298,7 +4298,7 @@ components:
         - id: "106193"
           type: "change"
           attributes:
-            goods_nomenclature_sid: "106193"
+            goods_nomenclature_sid: 106193
             goods_nomenclature_item_id: "7606129292"
             productline_suffix: "10"
             end_line: false
@@ -4308,7 +4308,7 @@ components:
         - id: "125323"
           type: "change"
           attributes:
-            goods_nomenclature_sid: "125323"
+            goods_nomenclature_sid: 125323
             goods_nomenclature_item_id: "2204109100"
             productline_suffix: "80"
             end_line: true
@@ -4320,8 +4320,8 @@ components:
       type: object
       properties:
         id:
-          type: integer
-          description: The `goods_nomenclature_sid` of the goods nomenclature. This is a unique identifier.
+          type: string
+          description: The id of the change within this response. This is always the `goods_nomenclature_sid` of the goods nomenclature that has changed.
         type:
           type: string
           description: Always 'change'.
@@ -4337,7 +4337,7 @@ components:
         id: "106193"
         type: "change"
         attributes:
-          goods_nomenclature_sid: "106193"
+          goods_nomenclature_sid: 106193
           goods_nomenclature_item_id: "7606129292"
           productline_suffix: "10"
           end_line: false
@@ -4375,7 +4375,7 @@ components:
         - change_type
         - change_date
       example:
-        goods_nomenclature_sid: "106193"
+        goods_nomenclature_sid: 106193
         goods_nomenclature_item_id: "7606129292"
         productline_suffix: "10"
         end_line: false


### PR DESCRIPTION
### Jira link

OTT-286

### What?

I have fixed:

- [x] id element is defined in code line 4323 as Integer, but the example in code line 4308 shows id as String (id is returned as String when curl command is issued).
- [x] id Description in code line 4324 is wrong
- [x] goods_nomenclature_sid is defined as Integer in code line 4352, but the example in line 4340 is Stringv (goods_nomenclature_sid is returned as Integer when curl command is issued).

### Why?

I am doing this because:

- The docs are currently inconsistent with the API itself
