### PR TITLE
GL-911: Change API docs to reflect API key provisioning process

### DIFF
--- a/source/green-lanes-sample-client.html
+++ b/source/green-lanes-sample-client.html
@@ -23,7 +23,7 @@
       commodity = null ;
       static targets = [
         "domain",
-        "token",
+        "key",
         "commodity",
         "origin",
         "gnCode",
@@ -72,8 +72,8 @@
       apiHeaders() {
         const headers = new Headers();
 
-        if (this.tokenTarget.value != '')
-          headers.append('Authorization', `Bearer ${this.tokenTarget.value}`);
+        if (this.keyTarget.value != '')
+          headers.append('X-Api-Key', `${this.keyTarget.value}`);
 
         return headers ;
       }
@@ -189,10 +189,10 @@
           </div>
 
           <div class="govuk-form-group">
-            <label class="govuk-label" for="token">
-              API Token
+            <label class="govuk-label" for="key">
+              API Key
             </label>
-            <input class="govuk-input" id="token" type="text" data-query-target="token" >
+            <input class="govuk-input" id="key" type="text" data-query-target="key" >
           </div>
         </fieldset>
 

--- a/source/green-lanes-terms-and-conditions.html.md
+++ b/source/green-lanes-terms-and-conditions.html.md
@@ -1,1 +1,115 @@
-# Terms and conditions 
+# Terms and Conditions for Use of the Trade Categorisation Tool
+
+By using this service, you (the software developer) indicate that you accept these terms and conditions and agree to abide by them.
+
+The service is owned and operated by the Online Trade Tariff Team within His Majesty's Revenue and Customs (HMRC).
+
+## Conditions of Use
+
+The API is designated for backend operations only and should not be directly integrated into any customer-facing interfaces, applications, or websites.
+
+Any access credentials are for the sole use of the UKIMS registered user to which they have been granted. They may be shared and used by third-party suppliers but must only be used for the purposes of providing services to the registered user. It is the responsibility of the registered user to ensure that their suppliers adhere to these terms and that access credentials are kept confidential.
+
+The API is only intended for the categorisation of trades between the Great Britain and the Northern Ireland that are classified as "Not at Risk" of onward movement out of Northern Ireland, where Northern Ireland is their final destination and place of use/consumption.
+
+The API is only available to UKIMS registered users. No access will be given without this authorisation apply for UKIMS [here](https://www.gov.uk/guidance/apply-for-authorisation-for-the-uk-internal-market-scheme-if-you-bring-goods-into-northern-ireland).
+
+By using the API, you agree not to discuss or publicly disclose any details, functionalities, or details of the performance of the API without prior written consent from HMRC.
+
+Usage of the API will be logged, and the data collected may be utilised to enhance the service.
+
+You may not conduct performance or security testing on the API.
+
+## What You Can Expect from Us
+
+We will:
+
+- Give you at least 6 months’ notice of major/breaking changes affecting any stable APIs.
+- Make sure any minor changes made to stable APIs are backwards compatible.
+- Provide reasonable notice of changes affecting beta APIs, which can change fairly frequently.
+- Warn you before we retire an API.
+
+## Accuracy of Data
+
+Although HMRC shall take all reasonable steps to ensure that the data provided is accurate and up to date before it is transmitted, no legal responsibility is accepted for any errors, omissions, or misleading statements.
+
+## Audits and Reviews
+
+HMRC reserves the right to carry out audits and reviews of your compliance with the terms of this service, and you, the customer, shall agree to co-operate fully with any such audit or review.
+
+## General Enquiries
+
+For general technical enquiries for this service, HMRC Trade Tariff Technical Support can be contacted between the hours of 09:00 and 17:00 Monday to Friday (excluding English bank holidays) by e-mailing [hmrc-trade-tariff-support-g@digital.hmrc.gov.uk](mailto:hmrc-trade-tariff-support-g@digital.hmrc.gov.uk).
+
+## Suspension and Termination
+
+Where HMRC considers the service to have been misused by the customer, it reserves the right to suspend the service offering immediately until appropriate evidence is supplied to allay concerns.
+
+HMRC reserves the right to withdraw the service at any point and will provide you with 7 working days' notice.
+
+## Disabling and Deactivation
+
+Should your API account remain unused for a period of 90 days, this may result in the disablement of your API key. If we do not receive contact from you within 120 days from the start of the unused period, your API account may be deleted.
+
+## Continuity of Service
+
+Where possible, HMRC will use reasonable endeavours to ensure that there is no break in the continuity of service and will only make changes when required.
+
+Outages may be required on occasions where essential upgrades to the service need to be implemented.
+
+HMRC will endeavour when possible to contact you with advance notice of any planned outages or maintenance. We will use the contact details you provided, therefore it is important that these are kept up to date by you. Should contact details change, you must inform the HMRC Trade Tariff Technical Support using the general contact details above.
+
+HMRC will limit the rate of requests made to the API service to ensure full functionality is maintained. We reserve the right to monitor usage of the service and to amend rate plans where necessary.
+
+## Service Incidents
+
+For issues with the service, the HMRC Trade Tariff Technical Support team can be contacted between the hours of 09:00 and 17:00 Monday to Friday (excluding English bank holidays) by e-mailing [hmrc-trade-tariff-support-g@digital.hmrc.gov.uk](mailto:hmrc-trade-tariff-support-g@digital.hmrc.gov.uk).
+
+## Disclaimer
+
+HMRC does not accept liability for loss or damage incurred by users of this service, whether direct, indirect, or consequential, whether caused by tort, breach of contract, or otherwise, in connection with our service, its use, the inability to use, or results of the use of our service, any websites linked to it, and any materials posted on it.
+
+This includes loss of:
+
+- Income or revenue
+- Business
+- Profits or contracts
+- Anticipated savings
+- Data
+- Goodwill
+- Tangible property
+- Wasted management or office time
+
+## Virus Protection
+
+HMRC will make every effort to check and test material at all stages of production. However, you must take your own precautions to ensure that the process you employ for accessing this service does not expose you to the risk of viruses, malicious computer code, or other forms of interference which may damage your own computer system.
+
+HMRC does not accept responsibility for any loss, disruption, or damage to your data or your computer system which may occur whilst using material derived from this service.
+
+## Viruses, Hacking, and Other Offences
+
+You, the customer, will not misuse the service by knowingly introducing viruses, trojans, worms, logic bombs, or other material which is malicious or technologically harmful. You will not attempt to gain unauthorised access to the service or any server, computer, or database connected to HMRC. You will not attack our service via a denial-of-service attack or a distributed denial-of-service attack.
+
+By breaching this provision, you would commit a criminal offence under the Computer Misuse Act 1990. We will report any such breach to the relevant law enforcement authorities, and we will co-operate with those authorities by disclosing your identity to them.
+
+## Use of HMRC's Logo
+
+The names, images, and logos identifying HMRC are proprietary marks of HMRC. The use or copying of our logos and/or any other third-party logos is not permitted without prior approval from the relevant copyright owner.
+
+## Changes
+
+HMRC reserves the right, at its discretion, to make changes to any part of this service, the information, or these terms. Should HMRC change these terms and conditions, the customer will be notified by email using the contact details provided at registration.
+
+## Severability
+
+If any of these terms and conditions are held to be invalid, unenforceable, or illegal for any reason, the remaining terms and conditions shall nevertheless continue in full force.
+
+If HMRC waives any rights available to it under these terms and conditions on one occasion, this does not mean that those rights will automatically be waived on any other occasion.
+
+## Events Beyond HMRC Control
+
+HMRC accepts no liability for any failure to comply with these terms and conditions where such failure is due to circumstances beyond our reasonable control.
+
+## Governing Law
+
+These terms and conditions shall be governed by and construed in accordance with the laws of England and Wales. Any dispute arising under these terms and conditions shall be subject to the exclusive jurisdiction of the courts of England and Wales.

--- a/source/green-lanes-terms-and-conditions.html.md
+++ b/source/green-lanes-terms-and-conditions.html.md
@@ -1,0 +1,1 @@
+# Terms and conditions 

--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -35,3 +35,15 @@ img {
         font-size: 0.65em;
     }
 }
+
+.email-template {
+  padding: 15px;
+  border: 1px solid #ddd;
+  white-space: pre-wrap;
+  text-align: left;
+  line-height: 1em;
+}
+
+.email-template strong {
+  font-weight: bold;
+}

--- a/source/v2/greenlanes-openapi.yaml
+++ b/source/v2/greenlanes-openapi.yaml
@@ -4,7 +4,7 @@ servers:
   - url: https://www.trade-tariff.service.gov.uk/xi/api/v2/green_lanes
 
 security:
-- bearerAuth: []
+- ApiKeyAuth: []
 
 info:
   version: "2"
@@ -31,16 +31,6 @@ info:
         An RSS feed is available for notification of changes - see below.
       </strong>
     </div>
-
-    ## Authentication
-
-    Access to these APIs will be restricted initially whilst they are in development. Approved partners requiring access should contact the Online Trade Tariff team.
-
-    The token should be included with the API request via the standard HTTP Authorization header, eg.
-
-    ```
-    Authorization: Token <SUPPLIED TOKEN>
-    ```
 
     ## Sample client
 
@@ -81,6 +71,10 @@ info:
     </details>
     <% end %>
 
+    ## Terms and Conditions
+
+      By using this API you agree to the [Terms and Conditions for use of the Green Lanes Categorisation Tool](/green-lanes-terms-and-conditions.html)
+
 paths:
   /green_lanes/category_assessments:
     get:
@@ -118,8 +112,8 @@ paths:
         /api/v2/green_lanes/category_assessments:
           lang: shell
           source: |-
-            curl -X GET -H "Authorization: Token TOKEN123" https://www.trade-tariff.service.gov.uk/xi/api/v2/green_lanes/category_assessments
-            curl -X GET -H "Authorization: Token TOKEN123" https://www.trade-tariff.service.gov.uk/xi/api/v2/green_lanes/category_assessments?as_of=2024-01-01
+            curl -X GET -H "X-Api-Key: a1b2c3defg4567" https://www.trade-tariff.service.gov.uk/xi/api/v2/green_lanes/category_assessments
+            curl -X GET -H "X-Api-Key: a1b2c3defg4567" https://www.trade-tariff.service.gov.uk/xi/api/v2/green_lanes/category_assessments?as_of=2024-01-01
 
   /green_lanes/goods_nomenclatures/{id}:
     get:
@@ -188,10 +182,10 @@ paths:
         /api/v2/goods_nomenclatures/0712909000:
           lang: shell
           source: |-
-            curl -X GET -H "Authorization: Token TOKEN123" https://www.trade-tariff.service.gov.uk/xi/api/v2/green_lanes/goods_nomenclatures/0712909000
-            curl -X GET -H "Authorization: Token TOKEN123" https://www.trade-tariff.service.gov.uk/xi/api/v2/green_lanes/goods_nomenclatures/0712909000?as_of=2024-01-01
-            curl -X GET -H "Authorization: Token TOKEN123" "https://www.trade-tariff.service.gov.uk/xi/api/v2/green_lanes/goods_nomenclatures/0712909000?filter\[geographical_area_id\]=US"
-            curl -X GET -H "Authorization: Token TOKEN123" "https://www.trade-tariff.service.gov.uk/xi/api/v2/green_lanes/goods_nomenclatures/0712909000?as_of=2024-01-01&filter\[geographical_area_id\]=US"
+            curl -X GET -H "X-Api-Key: a1b2c3defg4567" https://www.trade-tariff.service.gov.uk/xi/api/v2/green_lanes/goods_nomenclatures/0712909000
+            curl -X GET -H "X-Api-Key: a1b2c3defg4567" https://www.trade-tariff.service.gov.uk/xi/api/v2/green_lanes/goods_nomenclatures/0712909000?as_of=2024-01-01
+            curl -X GET -H "X-Api-Key: a1b2c3defg4567" "https://www.trade-tariff.service.gov.uk/xi/api/v2/green_lanes/goods_nomenclatures/0712909000?filter\[geographical_area_id\]=US"
+            curl -X GET -H "X-Api-Key: a1b2c3defg4567" "https://www.trade-tariff.service.gov.uk/xi/api/v2/green_lanes/goods_nomenclatures/0712909000?as_of=2024-01-01&filter\[geographical_area_id\]=US"
   /green_lanes/themes:
     get:
       summary: Returns a list of all themes
@@ -214,13 +208,22 @@ paths:
         /api/v2/green_lanes/themes:
           lang: shell
           source: |-
-            curl -X GET -H "Authorization: Token TOKEN123" https://www.trade-tariff.service.gov.uk/xi/api/v2/green_lanes/themes
+            curl -X GET -H "X-Api-Key: a1b2c3defg4567" https://www.trade-tariff.service.gov.uk/xi/api/v2/green_lanes/themes
 
 components:
   securitySchemes:
-    bearerAuth:
-      type: http
-      scheme: bearer
+    ApiKeyAuth:
+      type: apiKey
+      in: header
+      name: X-Api-Key
+      description: |
+        Access to these APIs will be restricted. Approved partners requiring access should contact the Online Trade Tariff team.
+
+        Those eligible traders will be supplied with a secret API key which should be included in the `X-Api-Key` header of every request, e.g.:
+
+        ```
+        X-Api-Key: a1b2c3defg4567
+        ```
 
   schemas:
     GoodsNomenclature:

--- a/source/v2/greenlanes-openapi.yaml
+++ b/source/v2/greenlanes-openapi.yaml
@@ -75,6 +75,62 @@ info:
 
       By using this API you agree to the [Terms and Conditions for use of the Green Lanes Categorisation Tool](/green-lanes-terms-and-conditions.html)
 
+    ## Instructions for requesting an API Key
+
+    <div class="govuk-details__text">
+        <h3>Prepare Your Details:</h3>
+        <p>Before sending the email, ensure you have the following information:</p>
+        <ul class="govuk-list--bullet">
+            <li>Your company’s name</li>
+            <li>Your EORI (Economic Operators Registration and Identification) number</li>
+            <li>A valid contact email address</li>
+            <li>Confirmation of your UKIMS (UK Integrated Tariff System) authorisation status</li>
+        </ul>
+    </div>
+
+    <div class="govuk-details__text">
+        <h3>Fill in the Template:</h3>
+        <p>Replace the placeholder text in the template with your actual information:</p>
+        <ul class="govuk-list--bullet">
+            <li>Insert your company name where it says <strong>[Your Company Name]</strong></li>
+            <li>Provide your EORI number where it says <strong>[Your EORI Number]</strong></li>
+            <li>Use your contact email in place of <strong>[Your Contact Email]</strong></li>
+            <li>Confirm your UKIMS authorisation where indicated.</li>
+        </ul>
+    </div>
+
+    <div class="govuk-details__text">
+        <h3>Send the Email:</h3>
+        <p>Send the completed email to <a href="mailto:hmrc-trade-tariff-support-g@digital.hmrc.gov.uk">hmrc-trade-tariff-support-g@digital.hmrc.gov.uk</a>.</p>
+    </div>
+
+    <div class="govuk-details__text">
+      <h3>E-mail template:</h3>
+    </div>
+
+    <div class="govuk-details__text">
+      <pre class="email-template">
+    <strong>Subject:</strong> Request for API Key - [Your Company Name]
+
+    Dear HMRC Trade Tariff Support Team,
+
+    I hope this message finds you well. I am writing to request an API key to access the HMRC Trade Tariff Categorisation API.
+
+    Please find our details below:
+
+    <strong>Company Name:</strong> [Your Company Name]
+    <strong>EORI Number:</strong> [Your EORI Number]
+    <strong>Contact Email:</strong> [Your Contact Email]
+    <strong>UKIMS Authorisation:</strong> [Please confirm your UKIMS authorisation status, e.g., “We confirm that our company is authorised under the UKIMS system.“]
+
+    Kind regards,
+    [Your Full Name]
+    [Your Position]
+      </pre>
+    </div>
+
+
+
 paths:
   /green_lanes/category_assessments:
     get:


### PR DESCRIPTION
### Jira link

[GL-911](https://transformuk.atlassian.net/browse/GL-911)

### What?

I have added/removed/altered:

- [ ] Change API docs to reflect API key provisioning process

### Why?

I am doing this because:

- To reflect the auth changes in api docs
