### PR TITLE
HMRC-501 | Remove text from categorisation openapi

### DIFF
--- a/source/v2/categorisation-openapi.yaml
+++ b/source/v2/categorisation-openapi.yaml
@@ -24,7 +24,6 @@ info:
       <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
       <strong class="govuk-warning-text__text">
         <span class="govuk-visually-hidden">Warning</span>
-        DRAFT: These APIs are currently in development and not yet available.
         <br /><br />
         The APIs are subject to change and this document will be updated as the API development evolves.
         <br /><br />


### PR DESCRIPTION
### Jira link

[HMRC-501](https://transformuk.atlassian.net/browse/HMRC-501)

### What?

I have added/removed/altered:

- [x] Remove 'DRAFT' wording from Categorisation API docs 

### Why?

I am doing this because:

- Getting ready for live
