### PR TITLE
HMRC-682 | Update categorisation api docs to have consistent desc for `as_of` param

### DIFF
--- a/source/v2/categorisation-openapi.yaml
+++ b/source/v2/categorisation-openapi.yaml
@@ -200,11 +200,10 @@ paths:
           in: query
           required: false
           description: |
-            Returns tariff data as it applies on the `as_of` date
+            Returns the category assessments across all commodities as they existed on the `as_of` date. Use the format `YYYY-MM-DD`
 
-            While this is not a required field it is advised to include it with all requests even
-            if requesting data for today to ensure the data returned is correct. As caching is used
-            on the API this will ensure the data returned is as expected.
+            While `as_of` is not a required field it is advised to include it with all requests even
+            if requesting data for today to ensure the data returned is correct.
           schema:
             type: string
             format: date


### PR DESCRIPTION
### Jira link

[HMRC-682](https://transformuk.atlassian.net/browse/HMRC-682)

### What?

I have added/removed/altered:

- [x] Changed the description for `as_of` param in categorisation api

### Why?

I am doing this because:

- We want the description of the `as_of` param to be consistent across docs
