### PR TITLE
HMRC-835 Added Dev Container for VSCode

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,27 @@
+# Use the latest Ruby 3.3 image
+FROM mcr.microsoft.com/devcontainers/ruby:3.3
+
+# Set environment variables
+ENV NODE_VERSION=23
+
+# Install dependencies
+RUN apt-get update && apt-get install -y \
+    curl \
+    graphviz \
+    git \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Node.js from NodeSource
+RUN curl -fsSL https://deb.nodesource.com/setup_${NODE_VERSION}.x | bash - && \
+    apt-get install -y nodejs && \
+    rm -rf /var/lib/apt/lists/*
+
+# Fix Yarn conflict (if needed)
+RUN rm -f /usr/bin/yarnpkg /usr/bin/yarn
+
+# Install Ruby 3.3.4 using ruby-install
+RUN curl -fsSL https://github.com/postmodern/ruby-install/archive/v0.8.2.tar.gz | tar xz && \
+    cd ruby-install-0.8.2 && \
+    make install && \
+    ruby-install --system ruby 3.3.4 && \
+    rm -rf ruby-install-0.8.2

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,9 @@
+{
+  "name": "trade_tariff_api_docs",
+  "dockerComposeFile": "docker-compose.yaml",
+  "service": "app",
+  "workspaceFolder": "/workspace",
+  "containerEnv": {},
+  "postCreateCommand": "make requirements",
+  "postStartCommand": "cd /workspace && make serve"
+}

--- a/.devcontainer/docker-compose.yaml
+++ b/.devcontainer/docker-compose.yaml
@@ -1,0 +1,9 @@
+version: "3"
+services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    volumes:
+      - ..:/workspace:cached
+    command: sleep infinity

--- a/README.md
+++ b/README.md
@@ -174,6 +174,13 @@ Type the following to start the server:
 make serve
 ```
 
+### VS Code Dev Container
+
+You can now clone the solution and open the folder in VS Code.
+Go to the command menu > Show and Run Commands
+Select "Dev-Containers: Open Folder in Container..."
+The container will be started and then the application will be built and started.
+
 You should now be able to view a live preview at <http://localhost:4567>.
 
 ## Publishing documentation


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HMRC-835

### What?

I have added Dev Container functionality

### Why?

I am doing this because:

- Solution uses older libraries, Graphviz, Middleman and EventMachine which does not always compile on M2 Macs
- Upgrade to latest ruby was looking like a re-write so this allows us to stick with Ruby 3.3.4 until the solution is migrated
- Allows devs to download app and run locally easily

![image](https://github.com/user-attachments/assets/51521ec8-678d-4b59-904f-13573c79c194)

