### PR TITLE
HMRC-989 update ruby version in devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -19,9 +19,9 @@ RUN curl -fsSL https://deb.nodesource.com/setup_${NODE_VERSION}.x | bash - && \
 # Fix Yarn conflict (if needed)
 RUN rm -f /usr/bin/yarnpkg /usr/bin/yarn
 
-# Install Ruby 3.3.4 using ruby-install
+# Install Ruby 3.4.2 using ruby-install
 RUN curl -fsSL https://github.com/postmodern/ruby-install/archive/v0.8.2.tar.gz | tar xz && \
     cd ruby-install-0.8.2 && \
     make install && \
-    ruby-install --system ruby 3.3.4 && \
+    ruby-install --system ruby 3.4.2 && \
     rm -rf ruby-install-0.8.2


### PR DESCRIPTION
### Jira link

[HOTT-989](https://transformuk.atlassian.net/browse/HMRC-989)

### What?

I have updated ruby version in devcontainer

### Why?

I am doing this because:

- app wasn't building in container with out of date version of ruby