### PR TITLE
HMRC-1065: Removes references to status checks

### DIFF
--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -15,11 +15,6 @@ It is accessed via [HTTPS][] and returns data in a [JSON][]
 format. The [reference documentation](reference.html) provides a thorough
 overview of the endpoints and the response format.
 
-The OTT team maintains a status page that indicates the overall health of various
-services including the backend and FPO applications.
-
-This can be reviewed [here][status]
-
 For internal documentation on the management of the API, please see the [internal documentation][tech-docs].
 
 ## What you can do with this API
@@ -126,5 +121,4 @@ please contact [hmrc-trade-tariff-support-g@digital.hmrc.gov.uk](mailto:hmrc-tra
 
 [HTTPS]: https://en.wikipedia.org/wiki/HTTPS
 [JSON]: https://en.wikipedia.org/wiki/JSON
-[status]: https://status.trade-tariff.service.gov.uk
 [tech-docs]: https://docs.trade-tariff.service.gov.uk


### PR DESCRIPTION
### Jira link

[HMRC-1065](https://transformuk.atlassian.net/browse/HMRC-1065)

![image](https://github.com/user-attachments/assets/3172c5e8-95e5-4cd2-b2a5-02d72e28d022)
![image](https://github.com/user-attachments/assets/70441007-ceba-490e-9069-fca3df8a2a26)


### What?

I have added/removed/altered:

- [x] Removed references to status pages

### Why?

I am doing this because:

- This service has been removed/is getting replaced
