### PR TITLE
HMRC-1458: Limit prod deploy trigger to main branch only

### DIFF
--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -7,6 +7,8 @@ on:
       - 'Deploy to staging'
     types:
       - completed
+    branches:
+      - main
 
 permissions:
   contents: read


### PR DESCRIPTION
### Jira link

[HMRC-1458](https://transformuk.atlassian.net/browse/HMRC-1458)

### What?

I have added/removed/altered:

- [x] added a condition to the production workflow so it only runs if the staging workflow was triggered from the main branch
### Why?

I am doing this because:

- Ensure production is only deployed after a successful automated staging deployment from the main branch

### Have you? (optional)

- [ ] Reviewed the documentation with the relevant stakeholders
- [ ] Followed the documentation through yourself to check it is correct
