### PR TITLE
HMRC-1758: Update to API pages post-enquiry form launch

### DIFF
--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -83,6 +83,6 @@ By using the FPO APIs, you agree to the [terms and conditions](https://api.trade
 
 When using the rest of our APIs, you agree to the following [terms](https://www.trade-tariff.service.gov.uk/terms).
 
-## Feedback on the API
+## Enquiries and feedback
 
-Your feedback helps us improve this service. Any suggestions, queries, or issues can be reported to [hmrc-trade-tariff-support-g@digital.hmrc.gov.uk](mailto:hmrc-trade-tariff-support-g@digital.hmrc.gov.uk).
+If you have any suggestions, queries or feedback about this service, please use the [Trade Tariff enquiry form](https://www.trade-tariff.service.gov.uk/enquiry_form).


### PR DESCRIPTION
### Jira link

[HMRC-1758](https://transformuk.atlassian.net/browse/HMRC-1758)

### What?

I have added/removed/altered:

- [ ] Updated Enquiries and feedback section

### Why?

I am doing this because:

- users are to directed the enquiry form rather than the email address
