### PR TITLE
OTTIMP-397: Add rate limiting banner to Trade Tariff API docs

### DIFF
--- a/source/categorisation-terms-and-conditions.html.md.erb
+++ b/source/categorisation-terms-and-conditions.html.md.erb
@@ -1,3 +1,5 @@
+<%= partial "layouts/rate_limiting_banner" %>
+
 # Terms and Conditions for Use of the Trade Categorisation Tool
 
 By using this service, you (the software developer) indicate that you accept these terms and conditions and agree to abide by them.

--- a/source/categorisation.html.md.erb
+++ b/source/categorisation.html.md.erb
@@ -14,6 +14,8 @@ highlight_theme: darkula
   <link href="/green_lanes.xml" type="application/atom+xml" rel="alternate" title="Windsor Framework Categorisation API changes feed" />
 <% end %>
 
+<%= partial "layouts/rate_limiting_banner" %>
+
 The Windsor Framework Categorisation API's provide access to the trade tariff data for trade with Northern Ireland.
 
 These APIs follow the JSON-API format for both request and response, in common with the other OTT APIs documented on this site.

--- a/source/fpo.html.md.erb
+++ b/source/fpo.html.md.erb
@@ -8,6 +8,8 @@ search: true
 highlight_theme: darkula
 ---
 
+<%= partial "layouts/rate_limiting_banner" %>
+
 # FPO APIs
 
 The FPO (Fast Parcel Operator) Commodity Code Identification Tool API is a free-to-use API available to UK Carrier scheme (UKC) registered organisations.

--- a/source/fpo/terms-and-conditions.html.md.erb
+++ b/source/fpo/terms-and-conditions.html.md.erb
@@ -1,3 +1,5 @@
+<%= partial "layouts/rate_limiting_banner" %>
+
 # Terms and conditions for use of the Fast Parcel Operator (FPO) Commodity Code Identification Tool
 By using this service you (the software developer) indicate that you accept these terms and conditions and agree to abide by them.
 

--- a/source/getting-started.html.md.erb
+++ b/source/getting-started.html.md.erb
@@ -2,6 +2,8 @@
 title: Getting started
 ---
 
+<%= partial "layouts/rate_limiting_banner" %>
+
 # Getting started
 
 ## How to use the GOV.UK Trade Tariff APIs

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -2,6 +2,8 @@
 title: About the Trade Tariff API - GOV.UK
 ---
 
+<%= partial "layouts/rate_limiting_banner" %>
+
 # About
 
 ## GOV.UK Trade Tariff API

--- a/source/layouts/_rate_limiting_banner.erb
+++ b/source/layouts/_rate_limiting_banner.erb
@@ -1,0 +1,9 @@
+<div class="govuk-notification-banner" role="region" aria-labelledby="rate-limiting-banner-title" data-module="govuk-notification-banner">
+  <div class="govuk-notification-banner__header">
+    <p class="govuk-notification-banner__title" id="rate-limiting-banner-title">Important</p>
+  </div>
+  <div class="govuk-notification-banner__content">
+    <p class="govuk-notification-banner__heading">From September 2026, rate limiting will apply to the Commodities API to protect service reliability.</p>
+    <p class="govuk-body">No action needed today. More guidance to follow</p>
+  </div>
+</div>

--- a/source/reference-data.html.md.erb
+++ b/source/reference-data.html.md.erb
@@ -2,6 +2,8 @@
 title: Reference data
 ---
 
+<%= partial "layouts/rate_limiting_banner" %>
+
 # Reference data
 
 ## Measure type series

--- a/source/reference.html.md.erb
+++ b/source/reference.html.md.erb
@@ -8,6 +8,8 @@ search: true
 highlight_theme: darkula
 ---
 
+<%= partial "layouts/rate_limiting_banner" %>
+
 # Trade Tariff Public API V2
 
 The Trade Tariff Public API provides way to request up-to-date

--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -1,4 +1,9 @@
 @import 'govuk_tech_docs';
+@import 'govuk/components/notification-banner/index';
+
+.technical-documentation > .govuk-notification-banner:first-child {
+  margin-top: govuk-spacing(6);
+}
 
 h1.anchored-heading {
     margin-top   : 1em;

--- a/source/the-commodities-api.html.md.erb
+++ b/source/the-commodities-api.html.md.erb
@@ -2,6 +2,8 @@
 title: Using the Commodities API
 ---
 
+<%= partial "layouts/rate_limiting_banner" %>
+
 # Using the Commodities API
 
 The commodities API is the most important of all of the APIs. It grants you access to virtually all the content that is present on a commodity code page on the Online Tariff. Along with all the other APIs, it is structured using the [JSON:API convention](https://jsonapi.org/), so that:

--- a/test/rate_limiting_banner_test.rb
+++ b/test/rate_limiting_banner_test.rb
@@ -1,0 +1,38 @@
+require "minitest/autorun"
+
+class RateLimitingBannerTest < Minitest::Test
+  BUILD_DIR = File.expand_path("../build", __dir__)
+  BANNER_HEADING = "From September 2026, rate limiting will apply to the Commodities API to protect service reliability."
+  BANNER_BODY = "No action needed today. More guidance to follow"
+  EXCLUDED_PAGES = %w[404.html].freeze
+  PAGES = %w[index.html reference.html the-commodities-api.html].freeze
+
+  def setup
+    self.class.build_site_once
+  end
+
+  def test_banner_is_rendered_on_key_docs_pages
+    PAGES.each do |page|
+      html = File.read(File.join(BUILD_DIR, page))
+
+      assert_includes html, BANNER_HEADING, "#{page} should include the banner heading"
+      assert_includes html, BANNER_BODY, "#{page} should include the banner body"
+    end
+  end
+
+  def test_banner_is_not_rendered_on_excluded_pages
+    EXCLUDED_PAGES.each do |page|
+      html = File.read(File.join(BUILD_DIR, page))
+
+      refute_includes html, BANNER_HEADING, "#{page} should not include the banner heading"
+      refute_includes html, BANNER_BODY, "#{page} should not include the banner body"
+    end
+  end
+
+  def self.build_site_once
+    return if @build_complete
+
+    system("bundle exec rake build", exception: true)
+    @build_complete = true
+  end
+end


### PR DESCRIPTION
### Jira link

[OTTIMP-397](https://transformuk.atlassian.net/browse/OTTIMP-397)

### What?

I have added/removed/altered:

- Added a shared ERB partial (`source/layouts/_rate_limiting_banner.erb`) containing the GOV.UK notification banner markup
- Each documentation page includes the banner via `<%= partial "layouts/rate_limiting_banner" %>` - one line per page, single source of truth for the copy
- Renamed five plain `.md` files to `.md.erb` so they can use ERB partial inclusion
- Imported the official `govuk-frontend` notification-banner SCSS component
- Added a regression test (`test/rate_limiting_banner_test.rb`) that verifies the banner renders on all docs pages and is absent from the 404 page

### Why?

I am doing this because:

- From September 2026, rate limiting will apply to the Commodities API and we need to inform API consumers early
- Users may land directly on reference or feature-specific pages (not just the homepage), so the banner must appear on every docs page
- The banner is excluded from the 404 page and the categorisation sample client page as they are not relevant documentation pages

### How it works

Pages that were previously plain Markdown (`.html.md`) have been renamed to `.html.md.erb` so they are processed through ERB first - enabling the partial call while preserving all existing Markdown content unchanged.

The notification banner title uses a `<p>` tag instead of the standard `<h2>` because the `govuk_tech_docs` table-of-contents builder crashes when it encounters an `<h2>` before the page's `<h1>`. The `<p>` is styled identically via the `.govuk-notification-banner__title` class.

<img width="1382" height="1034" alt="Screenshot 2026-03-23 at 10 05 57" src="https://github.com/user-attachments/assets/322826e2-92a3-4b33-8597-fa4d012e38a9" />


### Have you?

- [x] Verified banner renders correctly on all documentation pages
- [x] Verified banner does NOT appear on 404 page
- [x] Verified banner does NOT appear on categorisation sample client page
- [x] Confirmed `bundle exec middleman build --clean` succeeds
- [x] Confirmed regression tests pass (2 tests, 16 assertions, 0 failures)
- [x] Confirmed built HTML is identical before/after DRY refactor