### PR TITLE
docs: clarify canonical API reference workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,9 @@ jobs:
       - name: Install graphviz
         run: sudo apt-get update && sudo apt-get install -yy graphviz
 
+      - name: Guard reference workflow docs
+        run: ./script/check-stale-reference-workflow.sh
+
       - name: Build static site
         run: make html
 

--- a/README.md
+++ b/README.md
@@ -2,14 +2,12 @@
 
 This is a microsite for providing documentation for the GOV.UK Tariff API.
 
-This documentation is built from source files in this repository and an
-[OpenAPI](https://github.com/OAI/OpenAPI-Specification) specification
-[file](/v2/openapi.yaml) for the Tariff API.
+This documentation is built from source files in this repository using the
+[GOV.UK Tech Docs Template][tech-docs-template].
 
-The framework for this documentation
-is provided by the [GOV.UK Tech Docs Template][tech-docs-template] and through
-the use of a [fork][forked-widdershins] of [widdershins][widdershins] to
-convert the [`openapi.yaml`][tariff-openapi] to Markdown.
+The main Trade Tariff API reference is currently maintained directly in
+`source/reference.html.md.erb`. The separate FPO documentation page keeps its
+own OpenAPI source in `source/fpo/fpo-commodity-tool-openapi.yaml`.
 
 These docs are deployed to the following URLs:
 
@@ -19,11 +17,15 @@ These docs are deployed to the following URLs:
 
 ## Updating content
 
-To update content of this site, modify the files under `source` directory, i.e., `source/v2/openapi.yaml`.
+To update content on this site, modify the files under the `source` directory.
 
-HTML pages are in the [`/source`][source-dir] of this repository and are authored using Markdown. You can make edits to these pages by making changes in a branch and then opening a pull request.
+Most pages are authored in Markdown or ERB under [`/source`][source-dir]. You
+can make edits by changing the relevant file in a branch and then opening a pull
+request.
 
-The [`/reference.html`](https://api.trade-tariff.service.gov.uk/#gov-uk-trade-tariff-api) page is built using the `source/v2/openapi.yaml` file, which is an [OAS 3.0](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md) document that describes the Trade Tariff API and is used to build the HTML documentation website.
+The main [`/reference.html`](https://api.trade-tariff.service.gov.uk/#gov-uk-trade-tariff-api)
+page is built from `source/reference.html.md.erb`, which is the current
+canonical source for that reference content.
 
 The OpenAPI Specification (OAS) defines a standard, language-agnostic interface to RESTful APIs which allows both humans and computers to discover and understand the capabilities of the service without access to source code, documentation, or through network traffic inspection. When properly defined, a consumer can understand and interact with the remote service with a minimal amount of implementation logic.
 
@@ -31,103 +33,30 @@ The OpenAPI Specification (OAS) defines a standard, language-agnostic interface 
 
 To update the Trade Tariff API documentation, you may follow this general workflow:
 
-- If the changes involve the content of the HTML pages ( `/index` and `/getting_started`), edit the corresponding `.md` or `.md.erb` template under `source/*`.
+- If the changes involve the content of the HTML pages (for example `/index` or
+  `/getting-started`), edit the corresponding `.md` or `.md.erb` template
+  under `source/*`.
 
   - edit `source/index.html.md.erb` or `source/getting-started.html.md`
   - open or view [http://localhost:4567](http://localhost:4567) in a browser, the browser should automatically reload the page after changes are saved
 
-- If the changes involve the API specification itself, edit the `source/v2/openapi.yaml` file. This file is used to build the HTML file `build/reference.html`.
+- If the changes involve the main API reference page, edit
+  `source/reference.html.md.erb`.
 
-  - edit `source/v2/openapi.yaml`
+  - edit `source/reference.html.md.erb`
 
   - ```shell
     make serve
     ```
 
-  - manually (re)load [http://localhost:4567](http://localhost:4567) in a browser when the Middleman server (re)starts
+  - manually reload [http://localhost:4567/reference.html](http://localhost:4567/reference.html)
+    in a browser when the Middleman server restarts
+
+- If the changes involve the FPO documentation's OpenAPI source, edit
+  `source/fpo/fpo-commodity-tool-openapi.yaml` and preview the generated page
+  through the local site build.
 
 - It is also useful to add an entry in the `NEWS.yml` file, this information will be published on the Latest News page for users viewing these docs. It will also be added to the `/feed.xml` atom feed for anyone subscribing for updates.
-
-### Support for multiple API versions
-
-As we release new versions of the API, we will continue to support older versions (until they're deprecated). Therefore, we should continue to publish that version's API reference and the corresponding `openapi.yaml` file.
-
-In order to do this, some modifications to the default Middleman templates and options are required:
-
-1. create a new `openapi.yaml` file for the new API version and a directory in which to store it
-
-```
-mkdir v2
-touch v2/openapi.yaml
-```
-
-2. edit `config/tech-docs.yml` - add new link in the header for old reference file, i.e.;
-
-```
- Reference: /reference.html
-```
-
-3. edit `Makefile`
-
-- add new task to generate old reference file
-- rename previous reference file, add "-v1" (or whatever the old version number is) to the output filename
-
-  ```
-  ./generate.js source/v1/openapi.yaml source/reference-v1.html.md.erb
-  ```
-
-### Editing the `openapi.yaml` file
-
-An OpenAPI document that conforms to the OpenAPI Specification is itself a JSON object, which may be represented either in JSON or YAML format. For this project, we are using the YAML format.
-
-#### Example from `openapi.yaml`
-
-```yaml
-paths:
-  /uk/api/sections:
-    get:
-      summary: Retrieves all sections
-      description: |
-        This resource represents _all sections_ in the Tariff.
-
-        Each section has a `position`, which is its numerical order within the Tariff, and a `section_id`, which is a unique record identifier.
-
-      tags:
-        - Sections
-      produces:
-        - application/json
-      responses:
-        200:
-          description: Sections were found
-          content:
-            application/vnd.hmrc.2.0+json:
-              schema:
-                $ref: "#/components/schemas/Sections"
-              example:
-                $ref: "#/components/schemas/Sections/example"
-        5XX:
-          description: Unexpected error.
-      x-code-samples:
-        /uk/api/sections:
-          lang: shell
-          source: |-
-            curl https://api.trade-tariff.service.gov.uk/uk/api/sections -H "Accept: application/vnd.hmrc.2.0+json" | jq
-```
-
-The example above is rendered into HTML:
-
-![Example screen showing rendered HTML for /uk/api/sections](build/images/example-1.png "Example of Section object in the documentation")
-
-### Use of [`$ref`](https://swagger.io/specification/#documentStructure)
-
-The `openapi.yaml` file makes use of [`$ref`](https://swagger.io/specification/#documentStructure) to refer to connected parts of the specification. In the example above, [`$ref`](https://swagger.io/specification/#documentStructure) is used to refer to the schema and example response in another part of the document.
-
-Information on `$ref`: <https://swagger.io/specification/#documentStructure>
-
-### Links
-
-- OAS 3.0 Specification (<https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#oasDocument>)
-- Swagger, upon which OAS is based (<https://swagger.io/specification/>)
 
 ## Running documentation locally
 
@@ -165,8 +94,9 @@ make requirements
 
 Whilst writing documentation we can run a middleman server to preview how the
 published version will look in the browser. After saving a change the preview in
-the browser will automatically refresh on HTML pages. However for changes to
-[`openapi.yaml`][tariff-openapi] you will need to restart the preview.
+the browser will automatically refresh on HTML pages. Changes to large ERB
+templates such as `source/reference.html.md.erb` may require a manual reload or
+server restart to pick up structural edits.
 
 Type the following to start the server:
 
@@ -205,8 +135,5 @@ at [api.trade-tariff.service.gov.uk](https://api.trade-tariff.service.gov.uk)
 
 [MIT License](LICENSE)
 
-[forked-widdershins]: https://github.com/alphagov/widdershins
-[widdershins]: https://github.com/Mermade/widdershins
-[tariff-openapi]: https://github.com/trade-tariff/trade-tariff-api-docs/tree/main/source/v2/openapi.yaml
 [source-dir]: https://github.com/trade-tariff/trade-tariff-api-docs/tree/main/source
 [tech-docs-template]: https://github.com/alphagov/tech-docs-template

--- a/script/check-stale-reference-workflow.sh
+++ b/script/check-stale-reference-workflow.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if rg -n 'source/v2/openapi\.yaml|generate\.js' README.md; then
+  echo
+  echo 'README.md still references the retired source/v2 OpenAPI workflow.'
+  echo 'Update the docs to describe the current canonical reference source instead.'
+  exit 1
+fi
+
+echo 'Reference workflow docs check passed.'


### PR DESCRIPTION
## Summary

This PR makes the reference-source workflow truthful again by documenting the current canonical source for the main API reference and adding a lightweight CI guard against reintroducing the retired `source/v2/openapi.yaml` / `generate.js` workflow.

## Why this is the smallest safe slice

It fixes the contributor-facing architecture drift identified in yesterday's report without attempting a risky regeneration project or changing the reference content itself.

## Changes

- update `README.md` to describe `source/reference.html.md.erb` as the canonical source for the main API reference
- remove stale instructions for the retired `source/v2/openapi.yaml` and `generate.js` flow
- add `script/check-stale-reference-workflow.sh` and run it from the reusable build workflow

## Verification

- `./script/check-stale-reference-workflow.sh`

## Follow-up

- decide later whether restoring a spec-driven generation seam is worth the maintenance cost

Fixes #186
