### PR TITLE
OTTIMP-31: Enable GTM tagging for api-docs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
         run: make html
 
       - name: Run layout and content tests
-        run: bundle exec ruby -I test test/rate_limiting_banner_test.rb test/footer_links_test.rb
+        run: bundle exec ruby -I test test/rate_limiting_banner_test.rb test/footer_links_test.rb test/analytics_test.rb
 
       - name: Upload build artifact
         if: success()

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-serve: html
+ serve: html
 	bundle exec middleman server
 
 html: requirements clean
@@ -14,7 +14,7 @@ clean:
 all: html
 
 test:
-	bundle exec ruby -I test test/rate_limiting_banner_test.rb test/footer_links_test.rb
+	bundle exec ruby -I test test/rate_limiting_banner_test.rb test/footer_links_test.rb test/analytics_test.rb
 
 update-tech-docs:
 	bundle update govuk_tech_docs && FIRST_TIME=false bundle exec middleman init . -T alphagov/tech-docs-template

--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -3,6 +3,7 @@ host: https://api.trade-tariff.service.gov.uk
 
 # Header-related options
 show_govuk_logo: true
+service_name: Trade Tariff API documentation
 service_link: /
 # phase: Beta
 
@@ -28,8 +29,8 @@ footer_links:
   Cookies: https://hub.trade-tariff.service.gov.uk/cookies
   Terms and conditions: https://www.trade-tariff.service.gov.uk/terms
 
-# Tracking ID from Google Analytics (e.g. UA-XXXX-Y)
-ga_tracking_id: UA-97208357-3
+# Google Analytics 4 via Google Tag Manager (same container as Developer Portal)
+ga4_gtm_tracking_id: GTM-KPM7NRDG
 
 # Table of contents depth – how many levels to include in the table of contents.
 # If your ToC is too long, reduce this number and we'll only show higher-level

--- a/source/categorisation-sample-client.html
+++ b/source/categorisation-sample-client.html
@@ -144,11 +144,77 @@
       }
     })
   </script>
+  <script>
+    const cookies_policy_cookie = document.cookie
+      .split('; ')
+      .find(cookie => cookie.split('=')[0] === 'cookies_policy')
+      ?.split('=')[1]
+
+    if (cookies_policy_cookie && JSON.parse(decodeURIComponent(cookies_policy_cookie)).usage) {
+      (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+      new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+      j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+      'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+      })(window,document,'script','dataLayer','GTM-KPM7NRDG');
+    }
+  </script>
 </head>
 
 <body class="govuk-template__body">
   <script>
     document.body.className += ' js-enabled' + ('noModule' in HTMLScriptElement.prototype ? ' govuk-frontend-supported' : '');
+  </script>
+  <div class="govuk-cookie-banner" data-nosnippet role="region" aria-label="Cookies on Trade Tariff API documentation" hidden="hidden" id="cookie-banner">
+    <div class="govuk-cookie-banner__message govuk-width-container">
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+          <h2 class="govuk-cookie-banner__heading govuk-heading-m">Cookies on Trade Tariff API documentation</h2>
+          <div class="govuk-cookie-banner__content">
+            <p class="govuk-body">We’d like to use analytics cookies so we can understand how you use the service and make improvements.</p>
+          </div>
+        </div>
+      </div>
+      <div class="govuk-button-group">
+        <button id="cookie-banner__accept" type="button" class="govuk-button" data-module="govuk-button">Accept analytics cookies</button>
+        <button id="cookie-banner__reject" type="button" class="govuk-button" data-module="govuk-button">Reject analytics cookies</button>
+        <a class="govuk-link" href="https://hub.trade-tariff.service.gov.uk/cookies">View cookies</a>
+      </div>
+    </div>
+  </div>
+  <script>
+    (function () {
+      const banner = document.getElementById('cookie-banner')
+      if (!banner) return
+
+      const readPolicy = () => {
+        const match = document.cookie.split('; ').find((c) => c.startsWith('cookies_policy='))
+        if (!match) return null
+        try {
+          return JSON.parse(decodeURIComponent(match.split('=').slice(1).join('=')))
+        } catch {
+          return null
+        }
+      }
+
+      const writePolicy = (policy) => {
+        const maxAge = 365 * 24 * 60 * 60
+        document.cookie = `cookies_policy=${encodeURIComponent(JSON.stringify(policy))}; path=/; max-age=${maxAge}; SameSite=Lax`
+      }
+
+      if (!readPolicy()) {
+        banner.hidden = false
+      }
+
+      document.getElementById('cookie-banner__accept')?.addEventListener('click', () => {
+        writePolicy({ usage: true, remember_settings: true })
+        window.location.reload()
+      })
+
+      document.getElementById('cookie-banner__reject')?.addEventListener('click', () => {
+        writePolicy({ usage: false, remember_settings: false })
+        banner.hidden = true
+      })
+    })()
   </script>
   <a href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
   <header class="govuk-header" role="banner" data-module="govuk-header">

--- a/test/analytics_test.rb
+++ b/test/analytics_test.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'minitest/autorun'
+require_relative 'rate_limiting_banner_test'
+
+class AnalyticsTest < Minitest::Test
+  BUILD_DIR = File.expand_path('../build', __dir__)
+  GTM_CONTAINER_ID = 'GTM-KPM7NRDG'
+  PAGES = %w[index.html reference.html categorisation-sample-client.html].freeze
+
+  def setup
+    RateLimitingBannerTest.build_site_once
+  end
+
+  def test_pages_include_gtm_snippet_and_cookie_banner
+    PAGES.each do |page|
+      html = File.read(File.join(BUILD_DIR, page))
+
+      assert_includes html, 'googletagmanager.com/gtm.js', "#{page} should include GTM bootstrap"
+      assert_includes html, GTM_CONTAINER_ID, "#{page} should include GTM container id"
+      assert_includes html, 'govuk-cookie-banner', "#{page} should include cookie banner"
+      assert_includes html, 'Accept analytics cookies', "#{page} should include accept cookies button"
+    end
+  end
+
+  def test_pages_do_not_include_legacy_universal_analytics
+    PAGES.each do |page|
+      html = File.read(File.join(BUILD_DIR, page))
+
+      refute_includes html, 'google-analytics.com/analytics.js', "#{page} should not include legacy UA"
+      refute_includes html, 'UA-97208357-3', "#{page} should not include legacy UA tracking id"
+    end
+  end
+end


### PR DESCRIPTION
### Jira link
https://transformuk.atlassian.net/browse/OTTIMP-31

### What?

I have added/removed/altered:

- [ ] Added GTM analytics 
