### PR TITLE
Fix case for title and other places

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -20,7 +20,7 @@ header_links:
 # /privacy and /cookies on this host as same-tab links; keep consistent with hub URLs below.
 hub_host: hub.trade-tariff.service.gov.uk
 
-# Footer meta links (same pattern as UK Trade Tariff Developer Portal)
+# Footer meta links (same pattern as UK Trade Tariff developer portal)
 footer_links:
   Developer portal: https://hub.trade-tariff.service.gov.uk
   Enquiry form: https://www.trade-tariff.service.gov.uk/enquiry_form

--- a/source/developer-portal.html.md.erb
+++ b/source/developer-portal.html.md.erb
@@ -15,7 +15,7 @@ The Developer Portal allows you to:
 At present, API key management is available for the Trade Tariff API and FPO API. Categorisation API keys will be added in a future phase.
 
 <a href="https://hub.trade-tariff.service.gov.uk/" role="button" draggable="false" class="govuk-button" data-module="govuk-button" target="_blank" rel="noreferrer noopener">
-  Sign up to the Trade Tariff API Developer Portal (opens in new tab)
+  Sign up to the Trade Tariff API developer portal (opens in new tab)
 </a>
 
 ## Why sign up to the Developer Portal?
@@ -44,7 +44,7 @@ Whether you are a large enterprise or an independent trader, the APIs provide co
 
 ## How can I register on the Developer Portal?
 
-Signing up to the Trade Tariff Developer Portal and accessing a higher rate limit could not be easier.
+Signing up to the Trade Tariff developer portal and accessing a higher rate limit could not be easier.
 
 You will need to verify your email address using a secure one-time link, as the Developer Portal uses passwordless sign-in.
 

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -61,7 +61,7 @@ For token endpoints per environment, example requests, token expiry and retry be
 
 ## Developer Portal
 
-The HMRC Trade Tariff Developer Portal allows you to:
+The HMRC Trade Tariff developer portal allows you to:
 
 - access official trade tariff information
 - create and manage your API keys
@@ -69,7 +69,7 @@ The HMRC Trade Tariff Developer Portal allows you to:
 - manage organisational details
 - invite new members and remove existing members
 
-<a href="https://hub.trade-tariff.service.gov.uk/" target="_blank" rel="noreferrer noopener">Sign up to the Trade Tariff API Developer Portal (opens in new tab)</a>.
+<a href="https://hub.trade-tariff.service.gov.uk/" target="_blank" rel="noreferrer noopener">Sign up to the Trade Tariff API developer portal (opens in new tab)</a>.
 
 More detail is on the [Developer Portal](/developer-portal.html) page.
 

--- a/source/layouts/_rate_limiting_banner.erb
+++ b/source/layouts/_rate_limiting_banner.erb
@@ -4,7 +4,7 @@
   </div>
   <div class="govuk-notification-banner__content">
     <p class="govuk-notification-banner__heading">From September 2026, rate limiting will apply to the Trade Tariff API to protect service reliability.</p>
-    <p class="govuk-body">Access a higher rate limit through the Trade Tariff Developer Portal.<br/>
+    <p class="govuk-body">Access a higher rate limit through the Trade Tariff developer portal.<br/>
       <a class="govuk-link" href="/developer-portal.html">Find out more about the Developer Portal</a>.
     </p>
   </div>

--- a/test/rate_limiting_banner_test.rb
+++ b/test/rate_limiting_banner_test.rb
@@ -3,7 +3,7 @@ require 'minitest/autorun'
 class RateLimitingBannerTest < Minitest::Test
   BUILD_DIR = File.expand_path('../build', __dir__)
   BANNER_HEADING = 'From September 2026, rate limiting will apply to the Trade Tariff API to protect service reliability.'
-  BANNER_BODY = 'Access a higher rate limit through the Trade Tariff Developer Portal.'
+  BANNER_BODY = 'Access a higher rate limit through the Trade Tariff developer portal.'
   BANNER_LINK_TEXT = 'Find out more about the Developer Portal'
   EXCLUDED_PAGES = %w[404.html].freeze
   PAGES = %w[index.html reference.html the-trade-tariff-api.html].freeze


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/OTTIMP-566

### What?
I have added/removed/altered:

- Updated user-facing copy from “Trade Tariff Developer Portal” / “Trade Tariff API Developer Portal” to “Trade Tariff developer portal” / “Trade Tariff API developer portal” on the home page, developer portal page, and rate-limiting banner
- Aligned the rate-limiting banner test with the new banner text
- Updated a related comment in tech-docs.yml

### Why?
I am doing this because:

- Product naming should use sentence case (“developer portal”) rather than title case (“Developer Portal”) for the branded service name
- Keeps api-docs consistent with existing nav/footer labels that already use “Developer portal”
