### PR TITLE
Require developer portal auth in Trade Tariff API docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ paths:
         /uk/api/sections:
           lang: shell
           source: |-
-            curl https://api.trade-tariff.service.gov.uk/uk/api/sections -H "Accept: application/vnd.hmrc.2.0+json" | jq
+            curl https://api.trade-tariff.service.gov.uk/uk/api/sections -H "Authorization: Bearer ${ACCESS_TOKEN}" -H "Accept: application/vnd.hmrc.2.0+json" | jq
 ```
 
 The example above is rendered into HTML:

--- a/source/developer-portal.html.md.erb
+++ b/source/developer-portal.html.md.erb
@@ -22,14 +22,10 @@ At present, API key management is available for the Trade Tariff API and FPO API
 
 From September 2026, rate limiting will apply to the Trade Tariff API. Rate limiting sets a cap on the number of requests you can make per minute.
 
-Registering on the Developer Portal gives you access to a higher request rate than unauthenticated access.
-
-By registering on the Developer Portal, you can access a higher rate limit of 750 requests per minute.
-
-Unauthenticated access has a lower rate limit than authenticated access.
+You need developer portal credentials to call the Trade Tariff API on <code>api.trade-tariff.service.gov.uk</code>. By registering on the Developer Portal, you can create API keys and access a rate limit of 750 requests per minute.
 
 <div class="govuk-inset-text">
-  <strong>Managed service host change:</strong> Trade Tariff keys issued through the Developer Portal are used against <code>api.trade-tariff.service.gov.uk</code>. If you are migrating from <code>www.trade-tariff.service.gov.uk</code>, update the base URL in your integration. See <a class="govuk-link" href="/the-trade-tariff-api.html#authenticating-with-managed-credentials">Authenticating with managed credentials</a> for details.
+  <strong>Managed service host change:</strong> Trade Tariff keys issued through the Developer Portal are used against <code>api.trade-tariff.service.gov.uk</code>, which requires OAuth 2.0 authentication. If you are migrating from <code>www.trade-tariff.service.gov.uk</code>, update the base URL in your integration and authenticate as described in <a class="govuk-link" href="/the-trade-tariff-api.html#authenticating-with-managed-credentials">Authenticating with managed credentials</a>.
 </div>
 
 ## Who can use the Developer Portal?

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -35,7 +35,7 @@ You will also be able to:
 
 There are multiple APIs available through the UK Trade Tariff Service covering different user needs and search criteria. Some of the core APIs are:
 
-- The Trade Tariff API provides detailed UK Trade Tariff data for imports and exports. It is ideal if you want to access structured trade tariff data across jurisdictions and time.
+- The Trade Tariff API provides detailed UK Trade Tariff data for imports and exports. It is ideal if you want to access structured trade tariff data across jurisdictions and time. Access requires registration on the Trade Tariff developer portal.
 - The Categorisation API relates to bringing goods in and out of Northern Ireland and determines whether goods qualify for the simplified procedures under the Windsor Framework.
 - The Fast Parcel Operator (FPO) Commodity Code Identification Tool API is for express operators handling time-dependent deliveries.
 
@@ -53,11 +53,11 @@ Additional APIs are available to support specific trade tariff and classificatio
 
 ## Authentication
 
-The GOV.UK Trade Tariff APIs can be used without authentication for basic access.
+The Trade Tariff API on `api.trade-tariff.service.gov.uk` requires managed developer credentials from the Trade Tariff developer portal. Register on the portal, then authenticate with an OAuth 2.0 `client_credentials` access token.
 
-When you use managed developer credentials (Trade Tariff API keys), authenticate with an OAuth 2.0 `client_credentials` access token. Send the same `Accept` header as for other requests in this documentation (`application/vnd.hmrc.2.0+json`) so responses are correctly formatted, together with `Authorization: Bearer <access_token>`.
+Send `Authorization: Bearer <access_token>` together with the `Accept` header used throughout this documentation (`application/vnd.hmrc.2.0+json`) so responses are correctly formatted.
 
-For token endpoints per environment, example requests, token expiry and retry behaviour, and sample code in several languages, see [Authenticating with managed credentials](/the-trade-tariff-api.html#authenticating-with-managed-credentials) in Using the Trade Tariff API.
+For token endpoints, example requests, token expiry and retry behaviour, and sample code in several languages, see [Authenticating with managed credentials](/the-trade-tariff-api.html#authenticating-with-managed-credentials) in Using the Trade Tariff API.
 
 ## Developer Portal
 

--- a/source/reference-data.html.md.erb
+++ b/source/reference-data.html.md.erb
@@ -47,7 +47,7 @@ surveillance, restrictions on import or export, prohibitions, etc. They are the 
 elements that define what a measure is.
 
 This list of measure types is occasionally updated. For the very latest list of measure
-types in use, access the [measure types API](https://api.trade-tariff.service.gov.uk/uk/api/measure_types).
+types in use, call the [measure types API](https://api.trade-tariff.service.gov.uk/uk/api/measure_types) with a developer portal access token (opening the URL in a browser without authentication will not work).
 
 ### Prohibition-type measures (series A)
 

--- a/source/reference.html.md.erb
+++ b/source/reference.html.md.erb
@@ -25,10 +25,20 @@ All requests to this API should be prefixed with the following URL:
 **https://api.trade-tariff.service.gov.uk/uk/api**
 
 <div class="govuk-inset-text">
-  This API was previously hosted at <code>www.trade-tariff.service.gov.uk</code>. Existing integrations should be updated to use <code>api.trade-tariff.service.gov.uk</code>.
+  This API was previously hosted at <code>www.trade-tariff.service.gov.uk</code>. Existing integrations should use <code>api.trade-tariff.service.gov.uk</code> with OAuth 2.0 credentials from the <a href="https://hub.trade-tariff.service.gov.uk/" target="_blank" rel="noreferrer noopener">Trade Tariff developer portal (opens in new tab)</a>.
 </div>
 
 You will need to specify the `Accept` header with the value `application/vnd.hmrc.2.0+json` to get a correctly formatted response.
+
+<div class="govuk-warning-text">
+  <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+  <strong class="govuk-warning-text__text">
+    <span class="govuk-warning-text__assistive">Warning</span>
+    All requests to <code>api.trade-tariff.service.gov.uk</code> require <code>Authorization: Bearer &lt;access_token&gt;</code> from the Trade Tariff developer portal, together with the <code>Accept</code> header above. See <a href="/the-trade-tariff-api.html#authenticating-with-managed-credentials">Authenticating with managed credentials</a>.
+  </strong>
+</div>
+
+Substitute your access token for <code>${ACCESS_TOKEN}</code> in the example requests below.
 
 ## Endpoints
 
@@ -40,12 +50,13 @@ Sections are numbered I to XXI covering broad groups of products.
 
 Each section has a `position`, which is its numerical order within the Tariff, and a `section_id`, which is a unique record identifier.
 
-This request does not require authentication.
+This request requires a valid OAuth 2.0 Bearer token from the Trade Tariff developer portal.
 
 **Example Request**
 
 ```shell
 curl https://api.trade-tariff.service.gov.uk/uk/api/sections \
+  -H "Authorization: Bearer ${ACCESS_TOKEN}" \
   -H "Accept: application/vnd.hmrc.2.0+json" | jq
 ```
 
@@ -101,6 +112,7 @@ position|path|integer|true|The `position` of the section to be retrieved
 
 ```shell
 curl https://api.trade-tariff.service.gov.uk/uk/api/sections/1 \
+  -H "Authorization: Bearer ${ACCESS_TOKEN}" \
   -H "Accept: application/vnd.hmrc.2.0+json"
 ```
 
@@ -208,12 +220,13 @@ Chapters are numbered 1 to 99 and cover more specific products than sections.
 
 Each chapter has a `goods_nomenclature_item_id`, which is a string of ten (10) digits.
 
-This request does not require authentication.
+This request requires a valid OAuth 2.0 Bearer token from the Trade Tariff developer portal.
 
 **Example Request**
 
 ```shell
 curl https://api.trade-tariff.service.gov.uk/uk/api/chapters \
+  -H "Authorization: Bearer ${ACCESS_TOKEN}" \
   -H "Accept: application/vnd.hmrc.2.0+json" | jq
 ```
 
@@ -261,7 +274,7 @@ Status|Meaning|Description|Schema
 
 Retrieves a chapter, given the first two (2) digits of its `goods_nomenclature_item_id` <p>This should be a zero-padded string of two digits.</p>
 
-This request does not require authentication.
+This request requires a valid OAuth 2.0 Bearer token from the Trade Tariff developer portal.
 
 **Parameters**
 
@@ -273,6 +286,7 @@ chapter_id|path|string|true|The `chapter_id` of the chapter to be retrieved, e.g
 
 ```shell
 curl https://api.trade-tariff.service.gov.uk/uk/api/chapters/34 \
+  -H "Authorization: Bearer ${ACCESS_TOKEN}" \
   -H "Accept: application/vnd.hmrc.2.0+json" | jq
 ```
 
@@ -380,7 +394,7 @@ Headings are a level below chapters and cover more specific products and product
 
 For this resource, `heading_id` is used to uniquely identify a heading and request it from the API. `heading_id` is the first four (4) digits of the heading's `goods_nomenclature_item_id` <p>`heading_id` should be a zero-padded string of four (4) digits.</p>
 
-This request does not require authentication.
+This request requires a valid OAuth 2.0 Bearer token from the Trade Tariff developer portal.
 
 **Parameters**
 
@@ -392,6 +406,7 @@ heading_id|path|string|true|The `heading_id` of the heading to be retrieved, e.g
 
 ```shell
 curl https://api.trade-tariff.service.gov.uk/uk/api/headings/0101 \
+  -H "Authorization: Bearer ${ACCESS_TOKEN}" \
   -H "Accept: application/vnd.hmrc.2.0+json" | jq
 ```
 
@@ -580,7 +595,7 @@ Subheadings are a level below headings and get specific about certain products. 
 
 This resource is uniquely identified by a combination of goods_nomenclature_item_id and productline_suffix.
 
-This request does not require authentication.
+This request requires a valid OAuth 2.0 Bearer token from the Trade Tariff developer portal.
 
 **Parameters**
 
@@ -593,6 +608,7 @@ productline_suffix|path|string|true|The two-digit product line suffix of the sub
 
 ```shell
 curl https://api.trade-tariff.service.gov.uk/uk/api/subheadings/0102291000-80 \
+  -H "Authorization: Bearer ${ACCESS_TOKEN}" \
   -H "Accept: application/vnd.hmrc.2.0+json" | jq
 ```
 
@@ -780,7 +796,7 @@ Commodities are products specified to the greatest extent by the tariff.
 
 This resource represents a single commodity. For this resource, `id` is a `goods_nomenclature_item_id` and it is used to uniquely identify a commodity and request it from the API. <p>`id` should be a string of ten (10) digits.</p>
 
-This request does not require authentication.
+This request requires a valid OAuth 2.0 Bearer token from the Trade Tariff developer portal.
 
 **Parameters**
 
@@ -792,6 +808,7 @@ id|path|string|true|The `id` of the commodity to be retrieved. This should be a 
 
 ```shell
 curl https://api.trade-tariff.service.gov.uk/uk/api/commodities/0101210000 \
+  -H "Authorization: Bearer ${ACCESS_TOKEN}" \
   -H "Accept: application/vnd.hmrc.2.0+json" | jq
 ```
 
@@ -1569,7 +1586,7 @@ Quotas allow a limited amount of goods to be imported at a lower duty rate. Thes
 
 Retrieves a paginated list of quota definitions, optionally filtered by a variety of parameters.
 
-This request does not require authentication.
+This request requires a valid OAuth 2.0 Bearer token from the Trade Tariff developer portal.
 
 **Parameters**
 
@@ -1590,6 +1607,7 @@ include|query|string|false|Retrieve quota balance events which show the history 
 
 ```shell
 curl https://api.trade-tariff.service.gov.uk/uk/api/quotas/search?goods_nomenclature_item_id=0805102200&geographical_area_id=EG&order_number=091784&status=not_blocked&page=1 \
+  -H "Authorization: Bearer ${ACCESS_TOKEN}" \
   -H "Accept: application/vnd.hmrc.2.0+json" | jq
 ```
 
@@ -1741,7 +1759,7 @@ Retrieves a list of additional _codes, with associated commodities.
 
 Retrieves a paginated list of additional_codes, filtered by parameters.
 
-This request does not require authentication.
+This request requires a valid OAuth 2.0 Bearer token from the Trade Tariff developer portal.
 
 **Parameters**
 
@@ -1755,7 +1773,8 @@ description|query|string|conditional|Retrieve additional_codes with description 
 
 ```shell
 curl https://api.trade-tariff.service.gov.uk/uk/api/additional_codes/search?code=200&type=B \
-     -H "Content-Type: application/vnd.hmrc.2.0+json"
+  -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+  -H "Accept: application/vnd.hmrc.2.0+json" | jq
 ```
 
 **Example Response**
@@ -1840,12 +1859,13 @@ Retrieves a list of additional code types.
 
 Retrieves a list of all additional_code_types without pagination and filtering.
 
-This request does not require authentication.
+This request requires a valid OAuth 2.0 Bearer token from the Trade Tariff developer portal.
 
 **Example Request**
 
 ```shell
 curl https://api.trade-tariff.service.gov.uk/uk/api/additional_code_types \
+  -H "Authorization: Bearer ${ACCESS_TOKEN}" \
   -H "Accept: application/vnd.hmrc.2.0+json" | jq
 ```
 
@@ -1889,7 +1909,7 @@ Retrieves the list of certificates, with the associated description and descript
 
 Retrieves a paginated list of certificates, filtered by `as_of param, if present.
 
-This request does not require authentication.
+This request requires a valid OAuth 2.0 Bearer token from the Trade Tariff developer portal.
 
 **Parameters**
 
@@ -1901,6 +1921,7 @@ as_of|query|string(date)|false|Retrieve the measure_types as they existed on the
 
 ```shell
 curl https://api.trade-tariff.service.gov.uk/uk/api/certificates \
+  -H "Authorization: Bearer ${ACCESS_TOKEN}" \
   -H "Accept: application/vnd.hmrc.2.0+json" | jq
 ```
 
@@ -1946,7 +1967,7 @@ Status|Meaning|Description|Schema
 
 Retrieves a list of certificates, with associated goods nomenclatures, filtered by parameters..
 
-This request does not require authentication.
+This request requires a valid OAuth 2.0 Bearer token from the Trade Tariff developer portal.
 
 **Parameters**
 
@@ -1960,6 +1981,7 @@ description|query|string|false|Retrieve certificates with `description` that con
 
 ```shell
 curl https://api.trade-tariff.service.gov.uk/uk/api/certificates/search?code=D005&type=D \
+  -H "Authorization: Bearer ${ACCESS_TOKEN}" \
   -H "Accept: application/vnd.hmrc.2.0+json" | jq
 ```
 
@@ -2025,12 +2047,13 @@ Status|Meaning|Description|Schema
 
 Retrieves a list of all certificate types, without pagination and filtering.
 
-This request does not require authentication.
+This request requires a valid OAuth 2.0 Bearer token from the Trade Tariff developer portal.
 
 **Example Request**
 
 ```shell
 curl https://api.trade-tariff.service.gov.uk/uk/api/certificate_types \
+  -H "Authorization: Bearer ${ACCESS_TOKEN}" \
   -H "Accept: application/vnd.hmrc.2.0+json" | jq
 ```
 
@@ -2070,7 +2093,7 @@ Status|Meaning|Description|Schema
 
 Retrieves a list of all measure_types.
 
-This request does not require authentication.
+This request requires a valid OAuth 2.0 Bearer token from the Trade Tariff developer portal.
 
 **Parameters**
 
@@ -2082,6 +2105,7 @@ as_of|query|string(date)|false|Retrieve the measure_types as they existed on the
 
 ```shell
 curl https://api.trade-tariff.service.gov.uk/uk/api/measure_types \
+  -H "Authorization: Bearer ${ACCESS_TOKEN}" \
   -H "Accept: application/vnd.hmrc.2.0+json" | jq
 ```
 
@@ -2123,7 +2147,7 @@ Retrieves a list of active quotas.
 
 Retrieves a list of active quotas and their definitions.
 
-This request does not require authentication.
+This request requires a valid OAuth 2.0 Bearer token from the Trade Tariff developer portal.
 
 **Parameters**
 
@@ -2135,6 +2159,7 @@ as_of|query|string(date)|false|Retrieve the quota_order_numbers as they existed 
 
 ```shell
 curl https://api.trade-tariff.service.gov.uk/uk/api/quota_order_numbers \
+  -H "Authorization: Bearer ${ACCESS_TOKEN}" \
   -H "Accept: application/vnd.hmrc.2.0+json" | jq
 ```
 
@@ -2171,7 +2196,7 @@ Measures refer to any restriction on importing or exporting products. Not all co
 
 This resource represents a single measure. For this resource, `measure_sid` is used to uniquely identify a measure and request it from the API.
 
-This request does not require authentication.
+This request requires a valid OAuth 2.0 Bearer token from the Trade Tariff developer portal.
 
 **Parameters**
 
@@ -2183,7 +2208,8 @@ measure_sid|path|integer|true|The `measure_sid` of the measure to be retrieved.
 
 ```shell
 curl https://api.trade-tariff.service.gov.uk/uk/api/measures/{measure_sid} \
-  -H 'Accept: application/json'
+  -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+  -H "Accept: application/vnd.hmrc.2.0+json" | jq
 ```
 
 **Example Response**
@@ -2286,7 +2312,7 @@ Status|Meaning|Description|Schema
 
 *Retrieves a list of the measure actions.*
 
-This request does not require authentication.
+This request requires a valid OAuth 2.0 Bearer token from the Trade Tariff developer portal.
 
 **Parameters**
 
@@ -2298,6 +2324,7 @@ as_of|query|string(date)|false|Retrieve the measure_actions as they existed on t
 
 ```shell
 curl https://api.trade-tariff.service.gov.uk/uk/api/measure_actions \
+  -H "Authorization: Bearer ${ACCESS_TOKEN}" \
   -H "Accept: application/vnd.hmrc.2.0+json" | jq
 ```
 
@@ -2330,7 +2357,7 @@ Status|Meaning|Description|Schema
 
 *Retrieves a list of the measure condition codes.*
 
-This request does not require authentication.
+This request requires a valid OAuth 2.0 Bearer token from the Trade Tariff developer portal.
 
 **Parameters**
 
@@ -2342,6 +2369,7 @@ as_of|query|string(date)|false|Retrieve the measure_condition_codes as they exis
 
 ```shell
 curl https://api.trade-tariff.service.gov.uk/uk/api/measure_condition_codes \
+  -H "Authorization: Bearer ${ACCESS_TOKEN}" \
   -H "Accept: application/vnd.hmrc.2.0+json" | jq
 ```
 
@@ -2378,7 +2406,7 @@ Retrieves a list of footnotes, with associated goods nomenclatures.
 
 Retrieves a list of footnotes, filtered by parameters.
 
-This request does not require authentication.
+This request requires a valid OAuth 2.0 Bearer token from the Trade Tariff developer portal.
 
 **Parameters**
 
@@ -2392,6 +2420,7 @@ description|query|string|false|Retrieve footnotes with `description` that contai
 
 ```shell
 curl https://api.trade-tariff.service.gov.uk/uk/api/footnotes/search?code=134&type=CD \
+  -H "Authorization: Bearer ${ACCESS_TOKEN}" \
   -H "Accept: application/vnd.hmrc.2.0+json" | jq
 ```
 
@@ -2448,12 +2477,13 @@ Status|Meaning|Description|Schema
 
 Retrieves a list of all footnote_types without pagination and filtering.
 
-This request does not require authentication.
+This request requires a valid OAuth 2.0 Bearer token from the Trade Tariff developer portal.
 
 **Example Request**
 
 ```shell
 curl https://api.trade-tariff.service.gov.uk/uk/api/footnote_types \
+  -H "Authorization: Bearer ${ACCESS_TOKEN}" \
   -H "Accept: application/vnd.hmrc.2.0+json" | jq
 ```
 
@@ -2529,7 +2559,7 @@ SID,Goods Nomenclature Item ID,Indents,Description,Product Line Suffix,Href,Form
 72763,0101900000,1,Other,80/uk/api/commodities/0101900000,Other,2002-01-01 00:00:00 UTC,,true,27624
 ```
 
-This request does not require authentication.
+This request requires a valid OAuth 2.0 Bearer token from the Trade Tariff developer portal.
 
 **Parameters**
 
@@ -2542,6 +2572,7 @@ as_of|query|string(date)|false|Retrieve goods nomenclatures as they existed on t
 
 ```shell
 curl https://api.trade-tariff.service.gov.uk/uk/api/goods_nomenclatures/section/1 \
+  -H "Authorization: Bearer ${ACCESS_TOKEN}" \
   -H "Accept: application/vnd.hmrc.2.0+json" | jq
 ```
 
@@ -2666,7 +2697,7 @@ SID,Goods Nomenclature Item ID,Indents,Description,Product Line Suffix,Href,Form
 72763,0101900000,1,Other,80/uk/api/commodities/0101900000,Other,2002-01-01 00:00:00 UTC,,true,27624
 ```
 
-This request does not require authentication.
+This request requires a valid OAuth 2.0 Bearer token from the Trade Tariff developer portal.
 
 **Parameters**
 
@@ -2679,6 +2710,7 @@ as_of|query|string(date)|false|Retrieve goods nomenclatures as they existed on t
 
 ```shell
 curl https://api.trade-tariff.service.gov.uk/uk/api/goods_nomenclatures/chapter/01 \
+  -H "Authorization: Bearer ${ACCESS_TOKEN}" \
   -H "Accept: application/vnd.hmrc.2.0+json" | jq
 ```
 
@@ -2802,7 +2834,7 @@ SID,Goods Nomenclature Item ID,Indents,Description,Product Line Suffix,Href,Form
 72763,0101900000,1,Other,80/uk/api/commodities/0101900000,Other,2002-01-01 00:00:00 UTC,,true,27624
 ```
 
-This request does not require authentication.
+This request requires a valid OAuth 2.0 Bearer token from the Trade Tariff developer portal.
 
 **Parameters**
 
@@ -2815,6 +2847,7 @@ as_of|query|string(date)|false|Retrieve goods nomenclatures as they existed on t
 
 ```shell
 curl https://api.trade-tariff.service.gov.uk/uk/api/goods_nomenclatures/heading/0101 \
+  -H "Authorization: Bearer ${ACCESS_TOKEN}" \
   -H "Accept: application/vnd.hmrc.2.0+json" | jq
 ```
 
@@ -2911,7 +2944,7 @@ Retrieves a list of search references by letter
 
 Retrieves a list of search references by letter
 
-This request does not require authentication.
+This request requires a valid OAuth 2.0 Bearer token from the Trade Tariff developer portal.
 
 **Parameters**
 
@@ -2923,6 +2956,7 @@ query.letter|query|string|false|Retrieve search references started with  `query.
 
 ```shell
 curl https://api.trade-tariff.service.gov.uk/uk/api/search_references.json?query.letter=c \
+  -H "Authorization: Bearer ${ACCESS_TOKEN}" \
   -H "Accept: application/vnd.hmrc.2.0+json" | jq
 ```
 
@@ -2980,12 +3014,13 @@ Retrieves a list of geographical areas or by specific country.
 
 Retrieves a list of geographical areas
 
-This request does not require authentication.
+This request requires a valid OAuth 2.0 Bearer token from the Trade Tariff developer portal.
 
 **Example Request**
 
 ```shell
 curl https://api.trade-tariff.service.gov.uk/uk/api/geographical_areas \
+  -H "Authorization: Bearer ${ACCESS_TOKEN}" \
   -H "Accept: application/vnd.hmrc.2.0+json" | jq
 ```
 
@@ -3062,12 +3097,13 @@ Status|Meaning|Description|Schema
 
 Retrieves a list of countries
 
-This request does not require authentication.
+This request requires a valid OAuth 2.0 Bearer token from the Trade Tariff developer portal.
 
 **Example Request**
 
 ```shell
 curl https://api.trade-tariff.service.gov.uk/uk/api/geographical_areas/countries \
+  -H "Authorization: Bearer ${ACCESS_TOKEN}" \
   -H "Accept: application/vnd.hmrc.2.0+json" | jq
 ```
 
@@ -3148,7 +3184,7 @@ Retrieves a list of goods nomenclature objects that have changes since the previ
 
 Changes are only available for the previous 30 days up to the current day. Requests for changes outside of these dates will results in an empty set of changes.
 
-This request does not require authentication.
+This request requires a valid OAuth 2.0 Bearer token from the Trade Tariff developer portal.
 
 **Parameters**
 
@@ -3160,6 +3196,7 @@ as_of|path|string(date)|true|Retrieve changes as they existed between the `as_of
 
 ```shell
 curl https://api.trade-tariff.service.gov.uk/uk/api/changes/2021-04-13 \
+  -H "Authorization: Bearer ${ACCESS_TOKEN}" \
   -H "Accept: application/vnd.hmrc.2.0+json" | jq
 ```
 
@@ -3212,7 +3249,7 @@ Retrieves relevant Rules of Origin schemes and rules.
 Retrieves a list of Schemes and corresponding rules which apply to the
 supplied heading and country codes
 
-This request does not require authentication.
+This request requires a valid OAuth 2.0 Bearer token from the Trade Tariff developer portal.
 
 **Parameters**
 
@@ -3225,6 +3262,7 @@ country_code|path|string|true|Two letter country code for the country you are tr
 
 ```shell
 curl https://api.trade-tariff.service.gov.uk/uk/api/rules_of_origin_schemes/392113/FR \
+  -H "Authorization: Bearer ${ACCESS_TOKEN}" \
   -H "Accept: application/vnd.hmrc.2.0+json" | jq
 ```
 
@@ -3376,7 +3414,7 @@ Returns a list of chemical substances based on the filter parameters.
 
 Returns chemical substances that match one or more of the following filter parameters. Not supplying a filter returns empty results.
 
-This request does not require authentication.
+This request requires a valid OAuth 2.0 Bearer token from the Trade Tariff developer portal.
 
 **Parameters**
 
@@ -3391,15 +3429,19 @@ filter.goods_nomenclature_sid|query|integer|false|Filter by a specific goods nom
 
 ```shell
 curl https://api.trade-tariff.service.gov.uk/uk/api/chemical_substances?filter.cus=0153778-6 \
+  -H "Authorization: Bearer ${ACCESS_TOKEN}" \
   -H "Accept: application/vnd.hmrc.2.0+json" | jq
 
 curl https://api.trade-tariff.service.gov.uk/uk/api/chemical_substances?filter.cus=90131-25-2 \
+  -H "Authorization: Bearer ${ACCESS_TOKEN}" \
   -H "Accept: application/vnd.hmrc.2.0+json" | jq
 
 curl https://api.trade-tariff.service.gov.uk/uk/api/chemical_substances?filter.goods_nomenclature_item_id=0712909090 \
+  -H "Authorization: Bearer ${ACCESS_TOKEN}" \
   -H "Accept: application/vnd.hmrc.2.0+json" | jq
 
 curl https://api.trade-tariff.service.gov.uk/uk/api/chemical_substances?filter.goods_nomenclature_sid=30725 \
+  -H "Authorization: Bearer ${ACCESS_TOKEN}" \
   -H "Accept: application/vnd.hmrc.2.0+json" | jq
 ```
 
@@ -3440,7 +3482,7 @@ Returns simplified procedural code measures indicating the current valuations.
 
 Valuations cover a 2 week window. Null valuations indicate no data for the given input filter period.
 
-This request does not require authentication.
+This request requires a valid OAuth 2.0 Bearer token from the Trade Tariff developer portal.
 
 **Parameters**
 
@@ -3455,14 +3497,17 @@ filter.simplified_procedural_code|query|string|false|Filter by the simplified pr
 ```shell
 # Fetch all measures
 curl https://api.trade-tariff.service.gov.uk/uk/api/simplified_procedural_code_measures \
+  -H "Authorization: Bearer ${ACCESS_TOKEN}" \
   -H "Accept: application/vnd.hmrc.2.0+json" | jq
 
 # Fetch a given 2 week window of measures
 curl https://api.trade-tariff.service.gov.uk/uk/api/simplified_procedural_code_measures?filter.from_date=2023-05-12&filter.to_date=2023-05-25 \
+  -H "Authorization: Bearer ${ACCESS_TOKEN}" \
   -H "Accept: application/vnd.hmrc.2.0+json" | jq
 
 # Fetch the full history of a given simplified procedural code
 curl https://api.trade-tariff.service.gov.uk/uk/api/simplified_procedural_code_measures?filter.simplified_procedural_code=1.10 \
+  -H "Authorization: Bearer ${ACCESS_TOKEN}" \
   -H "Accept: application/vnd.hmrc.2.0+json" | jq
 ```
 
@@ -3504,12 +3549,13 @@ Retrieves a list of all the preference codes
 
 See <a href="https://www.gov.uk/government/publications/preference-codes-for-data-element-417-of-the-customs-declaration-service" target="_blank" rel="noreferrer noopener">Preference code Guidance (opens in new tab)</a> for more details.
 
-This request does not require authentication.
+This request requires a valid OAuth 2.0 Bearer token from the Trade Tariff developer portal.
 
 **Example Request**
 
 ```shell
 curl https://api.trade-tariff.service.gov.uk/uk/api/preference_codes \
+  -H "Authorization: Bearer ${ACCESS_TOKEN}" \
   -H "Accept: application/vnd.hmrc.2.0+json" | jq
 ```
 
@@ -3542,7 +3588,7 @@ This resource represents the exchange rates period and exchange rates years.
 You can use the period to work out which months there are exchange rates for the given type.
 For example, the spot and average types only produce rates in March and December.
 
-This request does not require authentication.
+This request requires a valid OAuth 2.0 Bearer token from the Trade Tariff developer portal.
 
 **Parameters**
 
@@ -3555,12 +3601,15 @@ filter.type|query|string|false|Possible values: spot, monthly, average.<br> <ul>
 
 ```shell
 curl https://api.trade-tariff.service.gov.uk/uk/api/exchange_rates/period_lists/2022?filter.type=monthly \
+  -H "Authorization: Bearer ${ACCESS_TOKEN}" \
   -H "Accept: application/vnd.hmrc.2.0+json" | jq
 
 curl https://api.trade-tariff.service.gov.uk/uk/api/exchange_rates/period_lists?filter.type=spot \
+  -H "Authorization: Bearer ${ACCESS_TOKEN}" \
   -H "Accept: application/vnd.hmrc.2.0+json" | jq
 
 curl https://api.trade-tariff.service.gov.uk/uk/api/exchange_rates/period_lists?filter.type=average \
+  -H "Authorization: Bearer ${ACCESS_TOKEN}" \
   -H "Accept: application/vnd.hmrc.2.0+json" | jq
 ```
 
@@ -3577,7 +3626,7 @@ Status|Meaning|Description|Schema
 This resource represents the exchange rates and exchange rate files.
 This will given you exchange rates of a given type for a given month and year.
 
-This request does not require authentication.
+This request requires a valid OAuth 2.0 Bearer token from the Trade Tariff developer portal.
 
 **Parameters**
 
@@ -3591,12 +3640,15 @@ filter.type|query|string|false|Possible values: spot, monthly, average.<br> <ul>
 
 ```shell
 curl https://api.trade-tariff.service.gov.uk/uk/api/exchange_rates/2021-10?filter.type=monthly \
+  -H "Authorization: Bearer ${ACCESS_TOKEN}" \
   -H "Accept: application/vnd.hmrc.2.0+json" | jq
 
 # Spot and average rates only produce data for March and December each year
 curl https://api.trade-tariff.service.gov.uk/uk/api/exchange_rates/2022-3?filter.type=spot \
+  -H "Authorization: Bearer ${ACCESS_TOKEN}" \
   -H "Accept: application/vnd.hmrc.2.0+json" | jq
 curl https://api.trade-tariff.service.gov.uk/uk/api/exchange_rates/2022-3?filter.type=average \
+  -H "Authorization: Bearer ${ACCESS_TOKEN}" \
   -H "Accept: application/vnd.hmrc.2.0+json" | jq
 ```
 

--- a/source/the-trade-tariff-api.html.md.erb
+++ b/source/the-trade-tariff-api.html.md.erb
@@ -16,15 +16,18 @@ You can use curl for interfacing with the API, however you can also use HTTPie o
 
 The GOV.UK Trade Tariff APIs are used to access content from the <a href="https://www.gov.uk/trade-tariff" target="_blank" rel="noreferrer noopener">UK Trade Tariff Service (opens in new tab)</a>.
 
-Using the Commodities API for example, if you want to access the commodity object for pure-bred breeding animals with the commodity code 0101210000. This can be viewed through this API by making a request to:
+Using the Commodities API for example, if you want to access the commodity object for pure-bred breeding animals with the commodity code 0101210000. You need a valid access token from the [Trade Tariff developer portal](https://hub.trade-tariff.service.gov.uk/) before calling the API. See [Authenticating with managed credentials](#authenticating-with-managed-credentials) for how to obtain one.
+
+Example request (substitute your access token):
 
 ```shell
 curl https://api.trade-tariff.service.gov.uk/uk/api/commodities/0101210000 \
+  -H "Authorization: Bearer ${ACCESS_TOKEN}" \
   -H "Accept: application/vnd.hmrc.2.0+json" | \
   jq
 ```
 
-You will need to specify the `Accept` header with the value `application/vnd.hmrc.2.0+json` to get a correctly formatted response.
+Send both `Authorization: Bearer <access_token>` and `Accept: application/vnd.hmrc.2.0+json` on every request to `api.trade-tariff.service.gov.uk`.
 
 The commodity object includes all the relevant information about the commodity including:
 
@@ -42,123 +45,15 @@ This API can be used in a similar way to access a wide range of information from
 
 Find out more about what information can be returned through the [Trade Tariff API](/reference.html).
 
-## Using the API without authentication
-
-You can use the Trade Tariff API without managed credentials for basic access. In this mode, include the `Accept` header and cache responses to reduce repeat calls.
-
-The examples below show simple commodity requests in different languages.
-
-### Ruby with Rails example
-
-It is simple to make use of the UK Trade Tariff API in your application. This example uses <a href="https://www.ruby-lang.org/en/" target="_blank" rel="noreferrer noopener">Ruby (opens in new tab)</a> with the built in `net/http` library to access the Commodities API. It also uses the <a href="https://guides.rubyonrails.org/caching_with_rails.html" target="_blank" rel="noreferrer noopener">Rails cache (opens in new tab)</a> to minimise the number of API calls.
-
-```ruby
-require 'net/http'
-require 'json'
-require 'uri'
-
-commodity = Rails.cache.fetch('commodity_0101210000', expires_in: 24.hours) do
-  uri = URI.parse('https://api.trade-tariff.service.gov.uk/uk/api/commodities/0101210000')
-  response = Net::HTTP.get(uri, { 'Accept' => 'application/vnd.hmrc.2.0+json' })
-  JSON.parse(response)
-end
-attributes = commodity['data']['attributes']
-
-puts "Commodity Code: #{attributes['goods_nomenclature_item_id']}"
-puts "Description: #{attributes['formatted_description']}"
-puts "Basic Duty Rate: #{attributes['basic_duty_rate']}"
-puts "Declarable: #{attributes['declarable']}"
-```
-
-This example uses the Ruby on Rails cache, which minimises the number of API calls. It is recommended you cache requests for 24 hours.
-
-### Node.js example
-
-You can also use the UK Trade Tariff API in a <a href="https://nodejs.org" target="_blank" rel="noreferrer noopener">Node.js (opens in new tab)</a> application. Below is an example using the built-in `https` module to access the Trade Tariff API.
-
-```javascript
-const https = require('https');
-const cache = new Map();
-const commodityCode = '0101210000';
-const cacheKey = `commodity_${commodityCode}`;
-const cacheDuration = 24 * 60 * 60 * 1000; // 24 hours in milliseconds
-
-const cached = cache.get(cacheKey);
-if (cached && Date.now() - cached.timestamp < cacheDuration) {
-  const attributes = cached.data.data.attributes;
-  console.log(`Commodity Code: ${attributes.goods_nomenclature_item_id}`);
-  console.log(`Description: ${attributes.formatted_description}`);
-  console.log(`Basic Duty Rate: ${attributes.basic_duty_rate}`);
-  console.log(`Declarable: ${attributes.declarable}`);
-} else {
-  https.get(`https://api.trade-tariff.service.gov.uk/uk/api/commodities/${commodityCode}`, {
-    headers: {
-      'Accept': 'application/vnd.hmrc.2.0+json'
-    }
-  }, (res) => {
-    let data = '';
-
-    res.on('data', (chunk) => {
-      data += chunk;
-    });
-
-    res.on('end', () => {
-      const commodity = JSON.parse(data);
-      cache.set(cacheKey, { data: commodity, timestamp: Date.now() });
-
-      const attributes = commodity.data.attributes;
-      console.log(`Commodity Code: ${attributes.goods_nomenclature_item_id}`);
-      console.log(`Description: ${attributes.formatted_description}`);
-      console.log(`Basic Duty Rate: ${attributes.basic_duty_rate}`);
-      console.log(`Declarable: ${attributes.declarable}`);
-    });
-  }).on('error', (err) => {
-    console.error(err);
-  });
-}
-```
-
-### Python example
-
-Finally, you can use the UK Trade Tariff API in a <a href="https://www.python.org/" target="_blank" rel="noreferrer noopener">Python (opens in new tab)</a> application. Below is an example using the built-in `urllib` library to access the Commodities API.
-
-```python
-import urllib.request
-import json
-import time
-
-cache = {}
-commodity_code = '0101210000'
-cache_key = f'commodity_{commodity_code}'
-cache_duration = 24 * 60 * 60  # 24 hours in seconds
-
-cached = cache.get(cache_key)
-if cached and time.time() - cached['timestamp'] < cache_duration:
-    commodity = cached['data']
-else:
-    url = f'https://api.trade-tariff.service.gov.uk/uk/api/commodities/{commodity_code}'
-    req = urllib.request.Request(url, headers={'Accept': 'application/vnd.hmrc.2.0+json'})
-    with urllib.request.urlopen(req) as response:
-        data = response.read().decode('utf-8')
-        commodity = json.loads(data)
-    cache[cache_key] = {'data': commodity, 'timestamp': time.time()}
-
-attributes = commodity['data']['attributes']
-print(f"Commodity Code: {attributes['goods_nomenclature_item_id']}")
-print(f"Description: {attributes['formatted_description']}")
-print(f"Basic Duty Rate: {attributes['basic_duty_rate']}")
-print(f"Declarable: {attributes['declarable']}")
-```
-
 ## Authenticating with managed credentials
 
 <div class="govuk-inset-text">
-  <strong>Host change:</strong> the managed Trade Tariff API is now served from <code>api.trade-tariff.service.gov.uk</code>. If your integration previously called <code>www.trade-tariff.service.gov.uk</code>, update the base URL in your client and token-authenticated requests.
+  <strong>Host change:</strong> the Trade Tariff API is served from <code>api.trade-tariff.service.gov.uk</code> and requires OAuth 2.0 credentials from the developer portal. If your integration previously called <code>www.trade-tariff.service.gov.uk</code>, update the base URL to <code>api.trade-tariff.service.gov.uk</code> and add token-authenticated requests as described below.
 </div>
 
-When you use managed developer credentials (Trade Tariff API keys), you should authenticate using an OAuth 2.0 `client_credentials` access token. This provides controlled access suitable for production integration.
+Register on the <a href="https://hub.trade-tariff.service.gov.uk/" target="_blank" rel="noreferrer noopener">Trade Tariff developer portal (opens in new tab)</a> to create API keys, then authenticate using an OAuth 2.0 `client_credentials` access token.
 
-As with unauthenticated requests, send the `Accept` header with the value `application/vnd.hmrc.2.0+json` for a correctly formatted response. Authenticated calls also need `Authorization: Bearer <access_token>`.
+Send the `Accept` header with the value `application/vnd.hmrc.2.0+json` for a correctly formatted response, together with `Authorization: Bearer <access_token>` on every request.
 
 ### OAuth 2.0 client_credentials (plain language)
 
@@ -580,6 +475,7 @@ To do this you will need to access the XI tariff. For example, for pure-bred bre
 
 ```shell
 curl https://api.trade-tariff.service.gov.uk/xi/api/commodities/0101210000 \
+  -H "Authorization: Bearer ${ACCESS_TOKEN}" \
   -H "Accept: application/vnd.hmrc.2.0+json" | \
   jq
 ```
@@ -811,7 +707,7 @@ Let's say we are importing domestic swine from the United States, a country with
 trade agreement. The import will need to fall back to the third-country duty
 (or <abbr title="Most Favoured Nation">MFN</abbr> duty).
 
-The image below shows the third-country duty for the same commodity ([0103911000](https://api.trade-tariff.service.gov.uk/commodities/0103911000)) as in the example above. You will see that there are three measures
+The image below shows the third-country duty for the same commodity ([0103911000](https://api.trade-tariff.service.gov.uk/uk/api/commodities/0103911000)) as in the example above. You will see that there are three measures
 pictured:
 
 - **Third-country duty** (for all countries)

--- a/templates/authentication_none.dot
+++ b/templates/authentication_none.dot
@@ -1,1 +1,1 @@
-This request does not require authentication.
+This request requires a valid OAuth 2.0 Bearer token from the Trade Tariff developer portal.


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HMRC-2249

### What?

I have added/removed/altered:

- [x] Removed “using the API without authentication” guidance and unauthenticated code samples from the Trade Tariff API docs
- [x] Updated About, Using the Trade Tariff API, API Reference, Developer Portal, and reference-data pages so `api.trade-tariff.service.gov.uk` examples require OAuth Bearer tokens
- [x] Added a global authentication warning on the API reference and updated all endpoint labels and curl examples
- [x] Updated `authentication_none.dot` and README example for consistency

### Why?

I am doing this because:

- HMRC-2243 found that docs tell readers they can call `api.trade-tariff.service.gov.uk` with only an `Accept` header, but production returns **401** without a Bearer token (API Gateway authorizer runs before Rails; `Accept` only selects API version).
- Following the docs literally still fails, which contradicted the About page (“without authentication for basic access”) and the “Using the API without authentication” section.
- Documentation should match live behaviour: the Trade Tariff API on `api.*` requires developer portal credentials. Examples and reference now direct integrators to OAuth `client_credentials` and the managed host migration path without implying anonymous access on `api.*`.
