### PR TITLE
Update the about page

### DIFF
--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -12,6 +12,20 @@ The GOV.UK Trade Tariff APIs make it easy to access the <a href="https://www.gov
 
 The APIs are useful for any business and individuals wanting to access up-to-date tariff data through a predictable and stable interface.
 
+## Developer Portal
+
+The HMRC Trade Tariff developer portal allows you to:
+
+- access official trade tariff information
+- create and manage your API keys
+- explore, test and integrate tariff data directly from HMRC
+- manage organisational details
+- invite new members and remove existing members
+
+<a href="https://hub.trade-tariff.service.gov.uk/" target="_blank" rel="noreferrer noopener">Sign up to the Trade Tariff API developer portal (opens in new tab)</a>.
+
+More detail is on the [Developer Portal](/developer-portal.html) page.
+
 ## What can you do with the APIs?
 
 Using the Trade Tariff APIs, you can search for commodities by:
@@ -59,20 +73,6 @@ Send `Authorization: Bearer <access_token>` together with the `Accept` header us
 
 For token endpoints, example requests, token expiry and retry behaviour, and sample code in several languages, see [Authenticating with managed credentials](/the-trade-tariff-api.html#authenticating-with-managed-credentials) in Using the Trade Tariff API.
 
-## Developer Portal
-
-The HMRC Trade Tariff developer portal allows you to:
-
-- access official trade tariff information
-- create and manage your API keys
-- explore, test and integrate tariff data directly from HMRC
-- manage organisational details
-- invite new members and remove existing members
-
-<a href="https://hub.trade-tariff.service.gov.uk/" target="_blank" rel="noreferrer noopener">Sign up to the Trade Tariff API developer portal (opens in new tab)</a>.
-
-More detail is on the [Developer Portal](/developer-portal.html) page.
-
 ## Caching
 
 The GOV.UK Trade Tariff is updated daily. To reduce the number of API calls, cache requests for 24 hours.
@@ -92,10 +92,6 @@ GOV.UK Trade Tariff APIs follow government HTTPS security guidelines. The Hypert
 ### Security patches
 
 We upgrade the framework and library code in GOV.UK Trade Tariff APIs to the latest versions for security and feature enhancements.
-
-## Support
-
-If you experience any issues or have questions regarding GOV.UK Trade Tariff APIs, please contact [hmrc-trade-tariff-support-g@digital.hmrc.gov.uk](mailto:hmrc-trade-tariff-support-g@digital.hmrc.gov.uk).
 
 ## Terms and Conditions
 


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/OTTIMP-510

### What?

I have added/removed/altered:

- [x] Removed the general `Support` email section from the About page
- [x] Moved the `Developer Portal` section to sit directly after the intro, before "What can you do with the APIs?"

### Why?

I am doing this because:

- The copy deck for the About page adds a Developer Portal section and removes general email support
- The Developer Portal section was already present but sat after Authentication; repositioning it improves discoverability and matches the intended page order
- General support should go through the enquiry form instead; the vulnerability-reporting email under Security and compliance is unchanged