### PR TITLE
Fix CodeQL actions analysis by adding explicit workflow with security-events: write

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,34 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 0 * * 0'
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [actions, javascript-typescript, ruby]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: /language:${{ matrix.language }}


### PR DESCRIPTION
## Summary

- The CodeQL default setup was failing on the `actions` language analysis with: _"Please check that your token is valid and has the required permissions: contents: read, security-events: write"_
- This adds an explicit CodeQL workflow file with the required `security-events: write` permission, replacing the default setup
- The `javascript-typescript` and `ruby` analyses were passing; this matches the same languages in the new workflow

## Test plan

- [ ] Confirm the new `Analyze (actions)` job completes successfully on this PR
- [ ] Confirm `Analyze (javascript-typescript)` and `Analyze (ruby)` continue to pass