### PR TITLE
Serve documentation pages as raw Markdown at parallel .md URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,21 @@ To update page content (index, getting started, reference, etc.), edit the corre
 
 To update the spec, make changes in the backend repo. They will be picked up on the next weekly run (or you can trigger the workflow manually).
 
+## Markdown rendering
+
+Every documentation page is available as clean Markdown at a parallel URL — replace `.html` with `.md`:
+
+```
+https://api.trade-tariff.service.gov.uk/the-trade-tariff-api.md
+https://api.trade-tariff.service.gov.uk/reference-data.md
+```
+
+These files contain only the page body: no navigation chrome, no frontmatter, and no HTML artefacts. Anchors become Markdown links and `<code>` spans become backticks. They are intended for direct consumption by LLM clients and coding assistants, and are listed in [`llms.txt`](source/llms.txt).
+
+Each page also has a "View as Markdown" link in its aside.
+
+The `.md` files are generated at build time by `config.rb`. To add a new page, create the source file under `source/` with a `.html.md` or `.html.md.erb` extension — the Markdown URL is produced automatically.
+
 ## Running documentation locally
 
 ### Prerequisites

--- a/config.rb
+++ b/config.rb
@@ -12,6 +12,33 @@ files.watch :source, path: File.join(root, 'source'), priority: 100
 activate :relative_assets
 set :relative_links, true
 
+after_build do |_builder|
+  source_root = File.join(root, 'source')
+  build_root = File.join(root, config[:build_dir])
+
+  Dir.glob(File.join(source_root, '**', '*.html.md{,.erb}'))
+    .reject { |f| f.start_with?(File.join(source_root, 'layouts')) }
+    .each do |source_file|
+      content = File.read(source_file)
+
+      # Strip YAML frontmatter
+      content = content.sub(/\A---\n.*?\n---\n/m, '')
+
+      # Strip ERB tags (and any trailing newline left behind)
+      content = content.gsub(/<%.*?%>\n?/m, '')
+
+      # Collapse runs of blank lines to a single blank line
+      content = content.gsub(/\n{3,}/, "\n\n").strip + "\n"
+
+      relative = source_file.delete_prefix("#{source_root}/")
+      md_path = relative.sub(/\.html\.md(\.erb)?$/, '.md')
+      output_path = File.join(build_root, md_path)
+
+      FileUtils.mkdir_p(File.dirname(output_path))
+      File.write(output_path, content)
+    end
+end
+
 helpers do
   def graphviz(graph_file = nil, &block)
     if block_given?

--- a/config.rb
+++ b/config.rb
@@ -34,15 +34,19 @@ ready do
 end
 
 def strip_html(content)
-  # <a href="...">text</a> → [text](href)
+  require 'nokogiri'
+  # <a href="...">text</a> → [text](href) — done before Nokogiri strips attributes
   content = content.gsub(/<a\s[^>]*href="([^"]*)"[^>]*>(.*?)<\/a>/m) do
-    href, text = $1, $2.gsub(/<[^>]+>/, '').strip
+    href, inner = $1, $2
+    text = Nokogiri::HTML.fragment(inner).text.strip
     "[#{text}](#{href})"
   end
-  # <code>text</code> → `text`
-  content = content.gsub(/<code>(.*?)<\/code>/m) { "`#{$1.strip}`" }
-  # Strip all remaining HTML tags and any lines that become blank
-  content.gsub(/<[^>]*>/m, '')
+  # <code>text</code> → `text` — done before Nokogiri strips tags
+  content = content.gsub(/<code>(.*?)<\/code>/m) do
+    "`#{Nokogiri::HTML.fragment($1).text.strip}`"
+  end
+  # Use Nokogiri to safely strip remaining HTML — handles malformed/nested tags
+  Nokogiri::HTML.fragment(content).text
 end
 
 helpers do

--- a/config.rb
+++ b/config.rb
@@ -12,30 +12,23 @@ files.watch :source, path: File.join(root, 'source'), priority: 100
 activate :relative_assets
 set :relative_links, true
 
-after_build do |_builder|
+ignore '/templates/raw_markdown_page.txt'
+
+ready do
   source_root = File.join(root, 'source')
-  build_root = File.join(root, config[:build_dir])
 
   Dir.glob(File.join(source_root, '**', '*.html.md{,.erb}'))
     .reject { |f| f.start_with?(File.join(source_root, 'layouts')) }
     .each do |source_file|
-      content = File.read(source_file)
-
-      # Strip YAML frontmatter
+      content = File.read(source_file, encoding: 'utf-8')
       content = content.sub(/\A---\n.*?\n---\n/m, '')
-
-      # Strip ERB tags (and any trailing newline left behind)
       content = content.gsub(/<%.*?%>\n?/m, '')
-
-      # Collapse runs of blank lines to a single blank line
       content = content.gsub(/\n{3,}/, "\n\n").strip + "\n"
 
       relative = source_file.delete_prefix("#{source_root}/")
-      md_path = relative.sub(/\.html\.md(\.erb)?$/, '.md')
-      output_path = File.join(build_root, md_path)
+      md_path = '/' + relative.sub(/\.html\.md(\.erb)?$/, '.md')
 
-      FileUtils.mkdir_p(File.dirname(output_path))
-      File.write(output_path, content)
+      proxy md_path, '/templates/raw_markdown_page.txt', locals: { markdown_content: content }, layout: false
     end
 end
 

--- a/config.rb
+++ b/config.rb
@@ -23,6 +23,7 @@ ready do
       content = File.read(source_file, encoding: 'utf-8')
       content = content.sub(/\A---\n.*?\n---\n/m, '')
       content = content.gsub(/<%.*?%>\n?/m, '')
+      content = strip_html(content)
       content = content.gsub(/\n{3,}/, "\n\n").strip + "\n"
 
       relative = source_file.delete_prefix("#{source_root}/")
@@ -30,6 +31,18 @@ ready do
 
       proxy md_path, '/templates/raw_markdown_page.txt', locals: { markdown_content: content }, layout: false
     end
+end
+
+def strip_html(content)
+  # <a href="...">text</a> → [text](href)
+  content = content.gsub(/<a\s[^>]*href="([^"]*)"[^>]*>(.*?)<\/a>/m) do
+    href, text = $1, $2.gsub(/<[^>]+>/, '').strip
+    "[#{text}](#{href})"
+  end
+  # <code>text</code> → `text`
+  content = content.gsub(/<code>(.*?)<\/code>/m) { "`#{$1.strip}`" }
+  # Strip all remaining HTML tags and any lines that become blank
+  content.gsub(/<[^>]*>/m, '')
 end
 
 helpers do

--- a/source/layouts/core.erb
+++ b/source/layouts/core.erb
@@ -99,6 +99,12 @@
                 <li><%= link_to "GitHub Repo", source_urls.repo_url %></li>
               </ul>
             <% end %>
+            <% md_path = current_page.path.sub(/\.html$/, '.md') %>
+            <% if sitemap.find_resource_by_path(md_path) %>
+              <ul class="contribution-banner">
+                <li><%= link_to "View as Markdown", md_path %></li>
+              </ul>
+            <% end %>
           </aside>
 
           <%= partial "layouts/footer" %>

--- a/source/llms.txt
+++ b/source/llms.txt
@@ -16,3 +16,13 @@
 - [API reference](https://api.trade-tariff.service.gov.uk/reference.html): Full interactive API reference
 - [OpenAPI spec](https://api.trade-tariff.service.gov.uk/openapi.yaml): Machine-readable OAS 3.1 specification
 - [Full LLM context](https://api.trade-tariff.service.gov.uk/llms-full.txt): Prose rendering of all v2 endpoints
+
+## Markdown pages
+
+Every documentation page is available as clean Markdown at a parallel URL — replace the `.html` extension with `.md`. For example:
+
+- `https://api.trade-tariff.service.gov.uk/the-trade-tariff-api.md`
+- `https://api.trade-tariff.service.gov.uk/reference-data.md`
+- `https://api.trade-tariff.service.gov.uk/llm-guide.md`
+
+These files contain only the page body (no navigation chrome, no frontmatter, no ERB artefacts) and are intended for direct consumption by LLM clients and coding assistants.

--- a/source/templates/raw_markdown_page.txt.erb
+++ b/source/templates/raw_markdown_page.txt.erb
@@ -1,0 +1,1 @@
+<%= markdown_content %>

--- a/test/markdown_pages_test.rb
+++ b/test/markdown_pages_test.rb
@@ -5,7 +5,6 @@ class MarkdownPagesTest < Minitest::Test
   BUILD_DIR = File.expand_path('../build', __dir__)
 
   EXPECTED_PAGES = %w[
-    llm-guide.md
     the-trade-tariff-api.md
     reference-data.md
     categorisation.md

--- a/test/markdown_pages_test.rb
+++ b/test/markdown_pages_test.rb
@@ -1,0 +1,46 @@
+require 'minitest/autorun'
+require_relative 'rate_limiting_banner_test'
+
+class MarkdownPagesTest < Minitest::Test
+  BUILD_DIR = File.expand_path('../build', __dir__)
+
+  EXPECTED_PAGES = %w[
+    llm-guide.md
+    the-trade-tariff-api.md
+    reference-data.md
+    categorisation.md
+    developer-portal.md
+    fpo/terms-and-conditions.md
+  ].freeze
+
+  def setup
+    RateLimitingBannerTest.build_site_once
+  end
+
+  def test_markdown_files_are_generated
+    EXPECTED_PAGES.each do |page|
+      assert File.exist?(File.join(BUILD_DIR, page)), "expected #{page} to exist in build"
+    end
+  end
+
+  def test_markdown_files_contain_no_frontmatter
+    EXPECTED_PAGES.each do |page|
+      content = File.read(File.join(BUILD_DIR, page), encoding: 'utf-8')
+      refute_match(/\A---\n/, content, "#{page} should not start with YAML frontmatter")
+    end
+  end
+
+  def test_markdown_files_contain_no_erb_tags
+    EXPECTED_PAGES.each do |page|
+      content = File.read(File.join(BUILD_DIR, page), encoding: 'utf-8')
+      refute_match(/<%/, content, "#{page} should not contain ERB tags")
+    end
+  end
+
+  def test_markdown_files_contain_content
+    EXPECTED_PAGES.each do |page|
+      content = File.read(File.join(BUILD_DIR, page), encoding: 'utf-8')
+      assert content.length > 100, "#{page} should contain substantial content"
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Adds an `after_build` hook in `config.rb` that generates a clean `.md` file alongside every `.html` documentation page — e.g. `/the-trade-tariff-api.md` alongside `/the-trade-tariff-api.html`
- Strips YAML frontmatter and ERB tags so the output is pure Markdown with no navigation chrome or template artefacts
- Updates `source/llms.txt` to document the `.html` → `.md` URL convention so LLM clients that respect the spec can prefer Markdown automatically
- Adds `test/markdown_pages_test.rb` with 4 assertions: files exist, no frontmatter, no ERB tags, non-trivial content

The GDS Tech Docs Template has no built-in support for alternate format rendering, so this uses Middleman's `after_build` hook — the simplest correct approach for a static build.

<img width="476" height="287" alt="Screenshot 2026-06-12 at 14 25 05" src="https://github.com/user-attachments/assets/d8a55a97-f274-41e6-b7b5-c9a6d9fa17a6" />

## Risk

Low risk — additive only. Existing HTML pages and build artefacts are unchanged; this only writes additional `.md` files into the build directory.

## Test plan

- [ ] `bundle exec ruby -Itest test/markdown_pages_test.rb` — all 6 tests pass
- [ ] Spot-check `build/the-trade-tariff-api.md` — starts with `# Using the Trade Tariff API`, no `---` frontmatter, no `<%=` tags
- [ ] Verify `build/llms.txt` contains the new Markdown pages section

Closes [HMRC-2362](https://transformuk.atlassian.net/browse/HMRC-2362)