### PR TITLE
Add MCP server documentation

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -15,6 +15,7 @@ header_links:
   Trade Tariff API: /the-trade-tariff-api.html
   Categorisation API: /categorisation.html
   FPO API: /fpo.html
+  MCP Server: /mcp.html
 
 # Developer Portal hostname (no scheme). Used by source/layouts/_footer.erb to treat
 # /privacy and /cookies on this host as same-tab links; keep consistent with hub URLs below.

--- a/source/llms.txt
+++ b/source/llms.txt
@@ -17,7 +17,7 @@ An MCP (Model Context Protocol) server is available for AI assistants that suppo
 - Endpoint: `https://mcp.trade-tariff.service.gov.uk/mcp`
 - Transport: streamable HTTP (MCP 2025-11-25)
 - Authentication: `Authorization: Bearer <access_token>` — register at https://hub.trade-tariff.service.gov.uk to obtain credentials
-- Tools: `list_sections`, `show_chapter`, `show_heading`, `lookup_commodity`, `search_commodities`, `navigate_hierarchy`
+- Tools: `list_sections`, `show_chapter`, `show_heading`, `lookup_commodity`, `search_commodities`, `navigate_hierarchy`, `rules_of_origin`, `search_quotas`, `list_geographical_areas`, `list_exchange_rates`, `list_certificate_types`, `search_additional_codes`
 - [MCP Server docs](https://api.trade-tariff.service.gov.uk/mcp.html)
 
 ## Docs

--- a/source/llms.txt
+++ b/source/llms.txt
@@ -10,6 +10,16 @@
 - Date-scoped endpoints accept an `as_of` query parameter (format: YYYY-MM-DD)
 - An XI (Northern Ireland) variant is available at `https://www.trade-tariff.service.gov.uk/xi/api/v2`
 
+## MCP Server
+
+An MCP (Model Context Protocol) server is available for AI assistants that support tool calling:
+
+- Endpoint: `https://mcp.trade-tariff.service.gov.uk/mcp`
+- Transport: streamable HTTP (MCP 2025-11-25)
+- No authentication required
+- Tools: `list_sections`, `show_chapter`, `show_heading`, `lookup_commodity`, `search_commodities`, `navigate_hierarchy`
+- [MCP Server docs](https://api.trade-tariff.service.gov.uk/mcp.html)
+
 ## Docs
 
 - [LLM integration guide](https://api.trade-tariff.service.gov.uk/llm-guide.html): Single-page prose guide covering auth, common patterns, errors, rate limiting, and gotchas — optimised for LLM consumption

--- a/source/llms.txt
+++ b/source/llms.txt
@@ -16,7 +16,7 @@ An MCP (Model Context Protocol) server is available for AI assistants that suppo
 
 - Endpoint: `https://mcp.trade-tariff.service.gov.uk/mcp`
 - Transport: streamable HTTP (MCP 2025-11-25)
-- No authentication required
+- Authentication: `Authorization: Bearer <access_token>` — register at https://hub.trade-tariff.service.gov.uk to obtain credentials
 - Tools: `list_sections`, `show_chapter`, `show_heading`, `lookup_commodity`, `search_commodities`, `navigate_hierarchy`
 - [MCP Server docs](https://api.trade-tariff.service.gov.uk/mcp.html)
 

--- a/source/mcp.html.md.erb
+++ b/source/mcp.html.md.erb
@@ -69,8 +69,8 @@ The MCP server uses streamable HTTP transport and OAuth 2.0 Authorization Code +
 
 **Via settings UI:**
 
-1. Open Claude Desktop and go to **Settings** → **Extensions**
-2. Click **Add MCP Server**
+1. Open Claude Desktop and go to **Settings** → **Connectors** → **Customize**
+2. Click **Add custom connector**
 3. Enter the server URL: `https://mcp.trade-tariff.service.gov.uk/`
 4. Click **Add** — Claude Desktop will prompt for your Hub **client_id** and **client_secret**
 

--- a/source/mcp.html.md.erb
+++ b/source/mcp.html.md.erb
@@ -63,6 +63,15 @@ The MCP server uses streamable HTTP transport and OAuth 2.0 Authorization Code +
 
 ### Claude Desktop
 
+**Via settings UI:**
+
+1. Open Claude Desktop and go to **Settings** → **Extensions**
+2. Click **Add MCP Server**
+3. Enter the server URL: `https://mcp.trade-tariff.service.gov.uk/`
+4. Click **Add** — Claude Desktop will prompt for your Hub **client_id** and **client_secret**
+
+**Via config file:**
+
 Add to `claude_desktop_config.json`:
 
 ```json
@@ -84,6 +93,15 @@ Restart Claude Desktop after saving. It will prompt for credentials on first use
 
 ### Cursor
 
+**Via settings UI:**
+
+1. Open **Cursor Settings** (`Cmd+,` / `Ctrl+,`) and go to **Tools & Integrations** → **MCP Servers**
+2. Click **Add new MCP server**
+3. Set the type to **HTTP** and enter the URL: `https://mcp.trade-tariff.service.gov.uk/`
+4. Click **Save** — Cursor will prompt for credentials on first connection
+
+**Via config file:**
+
 Add to your global config or a project-scoped `.cursor/mcp.json`:
 
 - **macOS / Linux**: `~/.cursor/mcp.json`
@@ -103,6 +121,15 @@ Cursor picks up changes without a restart and will prompt for credentials on fir
 
 ### Windsurf
 
+**Via settings UI:**
+
+1. Open **Windsurf Settings** and navigate to the **MCP** section
+2. Click **Add Server**
+3. Enter the server URL: `https://mcp.trade-tariff.service.gov.uk/`
+4. Click **Save** and restart Windsurf when prompted
+
+**Via config file:**
+
 Add to your Windsurf MCP config:
 
 - **macOS / Linux**: `~/.codeium/windsurf/mcp_config.json`
@@ -121,6 +148,15 @@ Add to your Windsurf MCP config:
 Restart Windsurf after saving.
 
 ### VS Code (GitHub Copilot)
+
+**Via settings UI:**
+
+1. Open the Command Palette (`Cmd+Shift+P` / `Ctrl+Shift+P`) and run **MCP: Add Server**
+2. Select **HTTP** as the server type
+3. Enter the URL: `https://mcp.trade-tariff.service.gov.uk/`
+4. Choose whether to add it to your user settings or workspace — VS Code will reload the config automatically
+
+**Via config file:**
 
 Add to `.vscode/mcp.json` in your workspace, or to your user-level `mcp.json`:
 

--- a/source/mcp.html.md.erb
+++ b/source/mcp.html.md.erb
@@ -176,4 +176,4 @@ The assistant will call the relevant tool and return structured tariff data in i
 
 ## Source code
 
-The MCP server is open source: [trade-tariff/trade-tariff-mcp](https://github.com/trade-tariff/trade-tariff-mcp).
+The MCP server is open source: [trade-tariff/mcp](https://github.com/trade-tariff/mcp).

--- a/source/mcp.html.md.erb
+++ b/source/mcp.html.md.erb
@@ -26,12 +26,18 @@ https://mcp.trade-tariff.service.gov.uk/mcp
 
 | Tool | Description |
 |------|-------------|
-| `list_sections` | List all top-level sections of the tariff |
-| `show_chapter` | Show a chapter by 2-digit ID (e.g. `01`) |
-| `show_heading` | Show a heading by 4-digit code (e.g. `0101`) |
-| `lookup_commodity` | Look up a commodity by 10-digit code (e.g. `0101210000`) |
-| `search_commodities` | Search by keyword (e.g. `"live horses"`) |
-| `navigate_hierarchy` | Look up any goods nomenclature entry by 4–10 digit code |
+| `list_sections` | List all sections of the tariff — the top-level groupings of goods |
+| `show_chapter` | Show a chapter by its 2-digit ID (e.g. `01` for Live Animals) |
+| `show_heading` | Show a heading by its 4-digit code (e.g. `0101` for live horses) |
+| `lookup_commodity` | Look up a commodity by its 10-digit code — returns description, measures, and duties |
+| `search_commodities` | Search the tariff by keyword — returns matching commodities, headings, and chapters |
+| `navigate_hierarchy` | Look up any goods nomenclature entry by a 4–10 digit code |
+| `rules_of_origin` | Return rules of origin schemes for a heading and country, including proof of origin required to claim a preferential rate |
+| `search_quotas` | Search quota definitions — check whether a commodity qualifies for quota relief and what the current balance is |
+| `list_geographical_areas` | List all countries and country groups recognised by the tariff — useful for finding country codes for duty or rules of origin lookups |
+| `list_exchange_rates` | List GBP exchange rates used in duty calculations (last 5 years) |
+| `list_certificate_types` | List all certificate types with descriptions — use this to understand what licences a measure may require |
+| `search_additional_codes` | Search additional codes such as Meursing codes for agricultural goods with variable duties |
 
 ### Optional parameters
 

--- a/source/mcp.html.md.erb
+++ b/source/mcp.html.md.erb
@@ -153,6 +153,15 @@ Restart Windsurf after saving.
 
 ### GitHub Copilot
 
+#### Copilot Chat on github.com (no IDE required)
+
+This is the simplest way to connect for non-technical users — no config file, no IDE.
+
+1. Go to [github.com/settings/copilot/features](https://github.com/settings/copilot/features) and find the **MCP servers** section
+2. Click **Add MCP server**
+3. Enter a name (e.g. `Trade Tariff`), the server URL `https://mcp.trade-tariff.service.gov.uk/`, and select **HTTP** as the connection type
+4. Save, then open **Copilot Chat** at [github.com/copilot](https://github.com/copilot) — you'll be prompted for your Dev Portal **client_id** and **client_secret** the first time the server is used
+
 #### VS Code
 
 **Via settings UI:**

--- a/source/mcp.html.md.erb
+++ b/source/mcp.html.md.erb
@@ -70,11 +70,19 @@ Add the following to your `claude_desktop_config.json`:
 }
 ```
 
-On macOS the file is at `~/Library/Application Support/Claude/claude_desktop_config.json`. Restart Claude Desktop after saving.
+The file location depends on your operating system:
+
+- **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
+- **Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
+
+Restart Claude Desktop after saving.
 
 ### Cursor
 
-Add to `~/.cursor/mcp.json` (global) or `.cursor/mcp.json` in your project root (project-scoped):
+Add to your global config or a project-scoped `.cursor/mcp.json` in your project root. Global config locations:
+
+- **macOS / Linux**: `~/.cursor/mcp.json`
+- **Windows**: `%USERPROFILE%\.cursor\mcp.json`
 
 ```json
 {
@@ -93,7 +101,10 @@ Cursor picks up changes without a restart.
 
 ### Windsurf
 
-Add to `~/.codeium/windsurf/mcp_config.json`:
+Add to your Windsurf MCP config. File locations:
+
+- **macOS / Linux**: `~/.codeium/windsurf/mcp_config.json`
+- **Windows**: `%USERPROFILE%\.codeium\windsurf\mcp_config.json`
 
 ```json
 {
@@ -112,7 +123,13 @@ Restart Windsurf after saving.
 
 ### VS Code (GitHub Copilot)
 
-Add to `.vscode/mcp.json` in your workspace, or to your user-level `mcp.json`. The `${input:tradeTariffToken}` placeholder means VS Code will prompt you for the token rather than storing it in plain text:
+Add to `.vscode/mcp.json` in your workspace (works on all platforms), or to your user-level `mcp.json`:
+
+- **macOS**: `~/Library/Application Support/Code/User/mcp.json`
+- **Windows**: `%APPDATA%\Code\User\mcp.json`
+- **Linux**: `~/.config/Code/User/mcp.json`
+
+The `${input:tradeTariffToken}` placeholder means VS Code will prompt you for the token rather than storing it in plain text:
 
 ```json
 {

--- a/source/mcp.html.md.erb
+++ b/source/mcp.html.md.erb
@@ -16,7 +16,7 @@ You need a tariff API token from the <a href="https://hub.trade-tariff.service.g
 
 The MCP server accepts this token in two ways depending on your client:
 
-- **Static header** — pass the token directly as `Authorization: Bearer <token>`. Most clients use this approach with a `headers` config field (see client instructions below).
+- **Static header** — pass the token as the `Authorization` header. Both `Authorization: Bearer <token>` and `Authorization: <token>` (without the `Bearer` prefix) are accepted. Most clients use this approach with a `headers` config field (see client instructions below).
 - **OAuth 2.0 client_credentials** — the MCP server advertises an OAuth discovery endpoint (`/.well-known/oauth-authorization-server`) for clients that perform the OAuth handshake automatically. When prompted, use anything as the client ID and your tariff API token as the client secret. The server returns the token as-is as the access token — it does not issue separate OAuth credentials.
 
 Requests without a valid token receive `401 Unauthorized`.

--- a/source/mcp.html.md.erb
+++ b/source/mcp.html.md.erb
@@ -144,9 +144,7 @@ The MCP server will appear in Copilot's agent mode tool list after VS Code reloa
 ### MCP Inspector (testing)
 
 ```bash
-npx @modelcontextprotocol/inspector \
-  --header "Authorization: Bearer YOUR_ACCESS_TOKEN" \
-  https://mcp.trade-tariff.service.gov.uk/
+npx @modelcontextprotocol/inspector https://mcp.trade-tariff.service.gov.uk/
 ```
 
 ## Example usage

--- a/source/mcp.html.md.erb
+++ b/source/mcp.html.md.erb
@@ -221,6 +221,17 @@ Add to `~/.copilot/mcp-config.json`:
 
 Restart the CLI session after saving — it will prompt for your Dev Portal **client_id** and **client_secret** on first use.
 
+### Microsoft Copilot
+
+The consumer Microsoft Copilot app (Windows/macOS) does not have a direct "add connector" option for custom MCP servers. MCP support is provided through **Microsoft Copilot Studio**, where you build or edit an agent and add the server as a tool:
+
+1. Open your agent in [Microsoft Copilot Studio](https://copilotstudio.microsoft.com/)
+2. Go to the **Tools** tab and select **Add tool** → **New tool** → **MCP**
+3. Enter the server URL `https://mcp.trade-tariff.service.gov.uk/` and complete the OAuth setup with your Dev Portal **client_id** and **client_secret**
+4. Save — the tool becomes available to anyone using that agent, including through the Microsoft Copilot app if the agent is published there
+
+This requires access to a Copilot Studio environment — it isn't something an end user can do from within the consumer Copilot app itself. See Microsoft's [MCP server setup guide](https://learn.microsoft.com/en-us/microsoft-copilot-studio/mcp-add-existing-server-to-agent) for details.
+
 ### ChatGPT
 
 ChatGPT connects to MCP servers as **Apps/Connectors**, which requires a paid plan.

--- a/source/mcp.html.md.erb
+++ b/source/mcp.html.md.erb
@@ -12,7 +12,7 @@ The server implements [MCP 2025-11-25](https://modelcontextprotocol.io) using st
 
 ## Before you start
 
-The MCP server requires credentials from the Trade Tariff developer hub. Here is how to get them:
+The MCP server requires credentials from the Trade Tariff Dev Portal. Here is how to get them:
 
 1. Go to the <a href="https://hub.trade-tariff.service.gov.uk/" target="_blank" rel="noreferrer noopener">Trade Tariff developer portal (opens in new tab)</a> and create a free account
 2. Once signed in, create a new **Trade Tariff key** — give it any name that identifies your project
@@ -63,7 +63,7 @@ Every tool accepts these optional parameters:
 
 ## Connecting AI clients
 
-The MCP server uses streamable HTTP transport and OAuth 2.0 Authorization Code + PKCE for authentication. Add the server URL and enter your Hub **client_id** and **client_secret** when your client prompts for credentials.
+The MCP server uses streamable HTTP transport and OAuth 2.0 Authorization Code + PKCE for authentication. Add the server URL and enter your Dev Portal **client_id** and **client_secret** when your client prompts for credentials.
 
 ### Claude Desktop
 
@@ -71,7 +71,7 @@ The MCP server uses streamable HTTP transport and OAuth 2.0 Authorization Code +
 
 1. Open Claude Desktop and go to **Settings** → **Connectors** → **Customize**
 2. Click **Add custom connector**
-3. Enter the server URL `https://mcp.trade-tariff.service.gov.uk/` along with your Hub **client_id** and **client_secret**
+3. Enter the server URL `https://mcp.trade-tariff.service.gov.uk/` along with your Dev Portal **client_id** and **client_secret**
 4. Click **Add**
 
 **Via config file:**

--- a/source/mcp.html.md.erb
+++ b/source/mcp.html.md.erb
@@ -49,9 +49,13 @@ Every tool accepts these optional parameters:
 | `uk`, `gb`, `great britain`, `united kingdom` | Great Britain (default) |
 | `xi`, `ni`, `northern ireland` | Northern Ireland |
 
-## Connecting to Claude Desktop
+## Connecting AI clients
 
-Add the following to your `claude_desktop_config.json`, substituting your access token:
+The MCP server uses streamable HTTP transport. Any client that supports this transport can connect by pointing it at the endpoint URL and passing your access token as an `Authorization: Bearer` header.
+
+### Claude Desktop
+
+Add the following to your `claude_desktop_config.json`:
 
 ```json
 {
@@ -66,15 +70,75 @@ Add the following to your `claude_desktop_config.json`, substituting your access
 }
 ```
 
-On macOS, `claude_desktop_config.json` is at `~/Library/Application Support/Claude/claude_desktop_config.json`.
+On macOS the file is at `~/Library/Application Support/Claude/claude_desktop_config.json`. Restart Claude Desktop after saving.
 
-After saving the file, restart Claude Desktop. The tariff tools will appear in the tools panel.
+### Cursor
 
-## Connecting other MCP clients
+Add to `~/.cursor/mcp.json` (global) or `.cursor/mcp.json` in your project root (project-scoped):
 
-Any client that supports streamable HTTP transport can connect. Pass the endpoint URL and an `Authorization: Bearer <access_token>` header.
+```json
+{
+  "mcpServers": {
+    "trade-tariff": {
+      "url": "https://mcp.trade-tariff.service.gov.uk/mcp",
+      "headers": {
+        "Authorization": "Bearer YOUR_ACCESS_TOKEN"
+      }
+    }
+  }
+}
+```
 
-To test with MCP Inspector:
+Cursor picks up changes without a restart.
+
+### Windsurf
+
+Add to `~/.codeium/windsurf/mcp_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "trade-tariff": {
+      "url": "https://mcp.trade-tariff.service.gov.uk/mcp",
+      "headers": {
+        "Authorization": "Bearer YOUR_ACCESS_TOKEN"
+      }
+    }
+  }
+}
+```
+
+Restart Windsurf after saving.
+
+### VS Code (GitHub Copilot)
+
+Add to `.vscode/mcp.json` in your workspace, or to your user-level `mcp.json`. The `${input:tradeTariffToken}` placeholder means VS Code will prompt you for the token rather than storing it in plain text:
+
+```json
+{
+  "servers": {
+    "trade-tariff": {
+      "type": "http",
+      "url": "https://mcp.trade-tariff.service.gov.uk/mcp",
+      "headers": {
+        "Authorization": "Bearer ${input:tradeTariffToken}"
+      }
+    }
+  },
+  "inputs": [
+    {
+      "id": "tradeTariffToken",
+      "type": "promptString",
+      "description": "Trade Tariff API access token",
+      "password": true
+    }
+  ]
+}
+```
+
+The MCP server will appear in Copilot's agent mode tool list after VS Code reloads the config.
+
+### MCP Inspector (testing)
 
 ```bash
 npx @modelcontextprotocol/inspector \

--- a/source/mcp.html.md.erb
+++ b/source/mcp.html.md.erb
@@ -151,7 +151,9 @@ Add to your Windsurf MCP config:
 
 Restart Windsurf after saving.
 
-### VS Code (GitHub Copilot)
+### GitHub Copilot
+
+#### VS Code
 
 **Via settings UI:**
 
@@ -180,6 +182,35 @@ Add to `.vscode/mcp.json` in your workspace, or to your user-level `mcp.json`:
 ```
 
 The MCP server will appear in Copilot's agent mode tool list after VS Code reloads the config.
+
+#### Visual Studio
+
+1. Go to **Tools** → **Options** → **GitHub** → **Copilot** → **MCP Servers**, or edit the solution-level `.mcp.json` directly
+2. Add an entry for the server with type `http` and the URL `https://mcp.trade-tariff.service.gov.uk/` (same JSON shape as the VS Code config above)
+3. Reload the MCP configuration from the Copilot Chat panel — it will prompt for credentials on first use
+
+#### JetBrains IDEs (IntelliJ, Rider, PyCharm, etc.)
+
+1. Open **Settings/Preferences** → **Languages & Frameworks** → **GitHub Copilot** → **MCP**
+2. Click the button to edit the MCP configuration file (it uses the same `servers` JSON shape as VS Code above) and add the `trade-tariff` entry with the server URL
+3. Apply and reload — the tool will appear in Copilot Chat's agent mode, and you'll be prompted for your Dev Portal credentials on first use
+
+#### Copilot CLI
+
+Add to `~/.copilot/mcp-config.json`:
+
+```json
+{
+  "mcpServers": {
+    "trade-tariff": {
+      "type": "http",
+      "url": "https://mcp.trade-tariff.service.gov.uk/"
+    }
+  }
+}
+```
+
+Restart the CLI session after saving — it will prompt for your Dev Portal **client_id** and **client_secret** on first use.
 
 ### ChatGPT
 

--- a/source/mcp.html.md.erb
+++ b/source/mcp.html.md.erb
@@ -21,7 +21,7 @@ Requests without a valid token receive `401 Unauthorized`.
 ## Endpoint
 
 ```
-https://mcp.trade-tariff.service.gov.uk/mcp
+https://mcp.trade-tariff.service.gov.uk/
 ```
 
 ## Available tools
@@ -69,7 +69,7 @@ Add to `claude_desktop_config.json`:
 {
   "mcpServers": {
     "trade-tariff": {
-      "url": "https://mcp.trade-tariff.service.gov.uk/mcp"
+      "url": "https://mcp.trade-tariff.service.gov.uk/"
     }
   }
 }
@@ -93,7 +93,7 @@ Add to your global config or a project-scoped `.cursor/mcp.json`:
 {
   "mcpServers": {
     "trade-tariff": {
-      "url": "https://mcp.trade-tariff.service.gov.uk/mcp"
+      "url": "https://mcp.trade-tariff.service.gov.uk/"
     }
   }
 }
@@ -112,7 +112,7 @@ Add to your Windsurf MCP config:
 {
   "mcpServers": {
     "trade-tariff": {
-      "url": "https://mcp.trade-tariff.service.gov.uk/mcp"
+      "url": "https://mcp.trade-tariff.service.gov.uk/"
     }
   }
 }
@@ -133,7 +133,7 @@ Add to `.vscode/mcp.json` in your workspace, or to your user-level `mcp.json`:
   "servers": {
     "trade-tariff": {
       "type": "http",
-      "url": "https://mcp.trade-tariff.service.gov.uk/mcp"
+      "url": "https://mcp.trade-tariff.service.gov.uk/"
     }
   }
 }
@@ -146,7 +146,7 @@ The MCP server will appear in Copilot's agent mode tool list after VS Code reloa
 ```bash
 npx @modelcontextprotocol/inspector \
   --header "Authorization: Bearer YOUR_ACCESS_TOKEN" \
-  https://mcp.trade-tariff.service.gov.uk/mcp
+  https://mcp.trade-tariff.service.gov.uk/
 ```
 
 ## Example usage

--- a/source/mcp.html.md.erb
+++ b/source/mcp.html.md.erb
@@ -12,12 +12,19 @@ The server implements [MCP 2025-11-25](https://modelcontextprotocol.io) using st
 
 ## Before you start
 
-You need a tariff API token from the <a href="https://hub.trade-tariff.service.gov.uk/" target="_blank" rel="noreferrer noopener">Trade Tariff developer portal (opens in new tab)</a>. Register there and create an API key — the secret value is your token.
+Register at the <a href="https://hub.trade-tariff.service.gov.uk/" target="_blank" rel="noreferrer noopener">Trade Tariff developer portal (opens in new tab)</a> and create an application. You will receive a **client_id** and **client_secret** — you need both.
 
-The MCP server accepts this token in two ways depending on your client:
+The MCP server accepts authentication in two ways depending on your client:
 
-- **Static header** — pass the token as the `Authorization` header. Both `Authorization: Bearer <token>` and `Authorization: <token>` (without the `Bearer` prefix) are accepted. Most clients use this approach with a `headers` config field (see client instructions below).
-- **OAuth 2.0 client_credentials** — the MCP server advertises an OAuth discovery endpoint (`/.well-known/oauth-authorization-server`) for clients that perform the OAuth handshake automatically. When prompted, use anything as the client ID and your tariff API token as the client secret. The server returns the token as-is as the access token — it does not issue separate OAuth credentials.
+- **OAuth 2.0** — for clients that perform the OAuth handshake automatically (such as Claude.ai connectors). The server implements Authorization Code + PKCE: when prompted, enter your Hub **client_id** and **client_secret**. The server exchanges these with Hub internally and returns a signed access token.
+- **Static bearer token** — for clients configured with a static `Authorization` header. Exchange your Hub credentials for a token first:
+
+  ```bash
+  curl -X POST https://auth.id.trade-tariff.service.gov.uk/oauth2/token \
+    -d "grant_type=client_credentials&client_id=<client_id>&client_secret=<client_secret>&scope=tariff/read"
+  ```
+
+  Use the returned `access_token` as your bearer token. Tokens expire — refresh them as needed.
 
 Requests without a valid token receive `401 Unauthorized`.
 
@@ -62,13 +69,13 @@ Every tool accepts these optional parameters:
 
 ## Connecting AI clients
 
-The MCP server uses streamable HTTP transport. Configuration varies slightly between clients, but in each case you are providing your tariff API token — either as a static `Authorization: Bearer` header or via an OAuth `client_credentials` prompt.
+The MCP server uses streamable HTTP transport. Configuration varies slightly between clients.
 
 ### Claude Desktop
 
-Claude Desktop supports OAuth discovery. When you add the server it will open a prompt asking for credentials — enter anything as the client ID and your tariff API token as the client secret.
+Claude Desktop supports OAuth discovery. When you add the server it will open a prompt asking for credentials — enter your Hub **client_id** and **client_secret**.
 
-Alternatively, you can supply the token as a static header in `claude_desktop_config.json`:
+Alternatively, exchange your credentials for a bearer token (see [Before you start](#before-you-start)) and supply it as a static header in `claude_desktop_config.json`:
 
 ```json
 {

--- a/source/mcp.html.md.erb
+++ b/source/mcp.html.md.erb
@@ -1,0 +1,93 @@
+---
+title: Trade Tariff MCP Server
+---
+
+<%= partial "layouts/rate_limiting_banner" %>
+
+# Trade Tariff MCP Server
+
+The Trade Tariff MCP (Model Context Protocol) server exposes UK trade tariff data as tools for AI assistants and LLM clients. It lets AI applications look up commodity codes, search the tariff hierarchy, and retrieve duty information directly — without needing to build API integration themselves.
+
+The server implements [MCP 2025-11-25](https://modelcontextprotocol.io) using streamable HTTP transport.
+
+## Endpoint
+
+```
+https://mcp.trade-tariff.service.gov.uk/mcp
+```
+
+The endpoint requires no authentication.
+
+## Available tools
+
+| Tool | Description |
+|------|-------------|
+| `list_sections` | List all top-level sections of the tariff |
+| `show_chapter` | Show a chapter by 2-digit ID (e.g. `01`) |
+| `show_heading` | Show a heading by 4-digit code (e.g. `0101`) |
+| `lookup_commodity` | Look up a commodity by 10-digit code (e.g. `0101210000`) |
+| `search_commodities` | Search by keyword (e.g. `"live horses"`) |
+| `navigate_hierarchy` | Look up any goods nomenclature entry by 4–10 digit code |
+
+### Optional parameters
+
+Every tool accepts these optional parameters:
+
+| Parameter | Description |
+|-----------|-------------|
+| `service` | Which tariff to query — `uk` (default) for Great Britain or `xi` for Northern Ireland |
+| `validity_date` | Return data as it appeared on a given date (`YYYY-MM-DD`). Defaults to today |
+
+**Service values accepted for `service`:**
+
+| Value | Tariff |
+|-------|--------|
+| `uk`, `gb`, `great britain`, `united kingdom` | Great Britain (default) |
+| `xi`, `ni`, `northern ireland` | Northern Ireland |
+
+## Connecting to Claude Desktop
+
+Add the following to your `claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "trade-tariff": {
+      "url": "https://mcp.trade-tariff.service.gov.uk/mcp"
+    }
+  }
+}
+```
+
+On macOS, `claude_desktop_config.json` is at `~/Library/Application Support/Claude/claude_desktop_config.json`.
+
+After saving the file, restart Claude Desktop. The tariff tools will appear in the tools panel.
+
+## Connecting other MCP clients
+
+Any client that supports streamable HTTP transport can connect. Pass the endpoint URL:
+
+```
+https://mcp.trade-tariff.service.gov.uk/mcp
+```
+
+For clients that support the MCP Inspector for testing:
+
+```bash
+npx @modelcontextprotocol/inspector https://mcp.trade-tariff.service.gov.uk/mcp
+```
+
+## Example usage
+
+Once connected, you can ask your AI assistant questions such as:
+
+- *"What commodity code covers fresh cut roses?"*
+- *"Look up commodity 0101210000 and tell me what duties apply."*
+- *"Show me chapter 84 of the Northern Ireland tariff."*
+- *"Search the tariff for 'electric vehicles'."*
+
+The assistant will call the relevant tool and return structured tariff data in its response.
+
+## Source code
+
+The MCP server is open source: [trade-tariff/trade-tariff-mcp](https://github.com/trade-tariff/trade-tariff-mcp).

--- a/source/mcp.html.md.erb
+++ b/source/mcp.html.md.erb
@@ -12,9 +12,14 @@ The server implements [MCP 2025-11-25](https://modelcontextprotocol.io) using st
 
 ## Before you start
 
-You need an access token from the <a href="https://hub.trade-tariff.service.gov.uk/" target="_blank" rel="noreferrer noopener">Trade Tariff developer portal (opens in new tab)</a>. Register there to obtain OAuth 2.0 `client_credentials` — a client ID and secret you exchange for a bearer token. See [Authenticating with managed credentials](/the-trade-tariff-api.html#authenticating-with-managed-credentials) for the full token flow.
+You need a tariff API token from the <a href="https://hub.trade-tariff.service.gov.uk/" target="_blank" rel="noreferrer noopener">Trade Tariff developer portal (opens in new tab)</a>. Register there and create an API key — the secret value is your token.
 
-Pass the token as an `Authorization: Bearer <access_token>` header on every request to the MCP endpoint.
+The MCP server accepts this token in two ways depending on your client:
+
+- **Static header** — pass the token directly as `Authorization: Bearer <token>`. Most clients use this approach with a `headers` config field (see client instructions below).
+- **OAuth 2.0 client_credentials** — the MCP server advertises an OAuth discovery endpoint (`/.well-known/oauth-authorization-server`) for clients that perform the OAuth handshake automatically. When prompted, use anything as the client ID and your tariff API token as the client secret. The server returns the token as-is as the access token — it does not issue separate OAuth credentials.
+
+Requests without a valid token receive `401 Unauthorized`.
 
 ## Endpoint
 
@@ -57,11 +62,13 @@ Every tool accepts these optional parameters:
 
 ## Connecting AI clients
 
-The MCP server uses streamable HTTP transport. Any client that supports this transport can connect by pointing it at the endpoint URL and passing your access token as an `Authorization: Bearer` header.
+The MCP server uses streamable HTTP transport. Configuration varies slightly between clients, but in each case you are providing your tariff API token — either as a static `Authorization: Bearer` header or via an OAuth `client_credentials` prompt.
 
 ### Claude Desktop
 
-Add the following to your `claude_desktop_config.json`:
+Claude Desktop supports OAuth discovery. When you add the server it will open a prompt asking for credentials — enter anything as the client ID and your tariff API token as the client secret.
+
+Alternatively, you can supply the token as a static header in `claude_desktop_config.json`:
 
 ```json
 {
@@ -76,7 +83,7 @@ Add the following to your `claude_desktop_config.json`:
 }
 ```
 
-The file location depends on your operating system:
+File locations:
 
 - **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
 - **Windows**: `%APPDATA%\Claude\claude_desktop_config.json`

--- a/source/mcp.html.md.erb
+++ b/source/mcp.html.md.erb
@@ -181,6 +181,15 @@ Add to `.vscode/mcp.json` in your workspace, or to your user-level `mcp.json`:
 
 The MCP server will appear in Copilot's agent mode tool list after VS Code reloads the config.
 
+### ChatGPT
+
+ChatGPT connects to MCP servers as **Apps/Connectors**, which requires a paid plan.
+
+1. Go to **Settings** → **Connectors** → **Advanced settings** and enable **Developer mode**
+2. Go to **Settings** → **Connectors** → **Add custom connector**
+3. Enter a name (e.g. `Trade Tariff`) and the server URL `https://mcp.trade-tariff.service.gov.uk/`
+4. Click **Save**, then enable the connector in a chat — you will be prompted for your Dev Portal **client_id** and **client_secret** on first use
+
 ### MCP Inspector (testing)
 
 ```bash

--- a/source/mcp.html.md.erb
+++ b/source/mcp.html.md.erb
@@ -10,13 +10,17 @@ The Trade Tariff MCP (Model Context Protocol) server exposes UK trade tariff dat
 
 The server implements [MCP 2025-11-25](https://modelcontextprotocol.io) using streamable HTTP transport.
 
+## Before you start
+
+You need an access token from the <a href="https://hub.trade-tariff.service.gov.uk/" target="_blank" rel="noreferrer noopener">Trade Tariff developer portal (opens in new tab)</a>. Register there to obtain OAuth 2.0 `client_credentials` — a client ID and secret you exchange for a bearer token. See [Authenticating with managed credentials](/the-trade-tariff-api.html#authenticating-with-managed-credentials) for the full token flow.
+
+Pass the token as an `Authorization: Bearer <access_token>` header on every request to the MCP endpoint.
+
 ## Endpoint
 
 ```
 https://mcp.trade-tariff.service.gov.uk/mcp
 ```
-
-The endpoint requires no authentication.
 
 ## Available tools
 
@@ -47,13 +51,16 @@ Every tool accepts these optional parameters:
 
 ## Connecting to Claude Desktop
 
-Add the following to your `claude_desktop_config.json`:
+Add the following to your `claude_desktop_config.json`, substituting your access token:
 
 ```json
 {
   "mcpServers": {
     "trade-tariff": {
-      "url": "https://mcp.trade-tariff.service.gov.uk/mcp"
+      "url": "https://mcp.trade-tariff.service.gov.uk/mcp",
+      "headers": {
+        "Authorization": "Bearer YOUR_ACCESS_TOKEN"
+      }
     }
   }
 }
@@ -65,16 +72,14 @@ After saving the file, restart Claude Desktop. The tariff tools will appear in t
 
 ## Connecting other MCP clients
 
-Any client that supports streamable HTTP transport can connect. Pass the endpoint URL:
+Any client that supports streamable HTTP transport can connect. Pass the endpoint URL and an `Authorization: Bearer <access_token>` header.
 
-```
-https://mcp.trade-tariff.service.gov.uk/mcp
-```
-
-For clients that support the MCP Inspector for testing:
+To test with MCP Inspector:
 
 ```bash
-npx @modelcontextprotocol/inspector https://mcp.trade-tariff.service.gov.uk/mcp
+npx @modelcontextprotocol/inspector \
+  --header "Authorization: Bearer YOUR_ACCESS_TOKEN" \
+  https://mcp.trade-tariff.service.gov.uk/mcp
 ```
 
 ## Example usage

--- a/source/mcp.html.md.erb
+++ b/source/mcp.html.md.erb
@@ -12,19 +12,9 @@ The server implements [MCP 2025-11-25](https://modelcontextprotocol.io) using st
 
 ## Before you start
 
-Register at the <a href="https://hub.trade-tariff.service.gov.uk/" target="_blank" rel="noreferrer noopener">Trade Tariff developer portal (opens in new tab)</a> and create an application. You will receive a **client_id** and **client_secret** — you need both.
+Register at the <a href="https://hub.trade-tariff.service.gov.uk/" target="_blank" rel="noreferrer noopener">Trade Tariff developer portal (opens in new tab)</a> and create an application. You will receive a **client_id** and **client_secret**.
 
-The MCP server accepts authentication in two ways depending on your client:
-
-- **OAuth 2.0** — for clients that perform the OAuth handshake automatically (such as Claude.ai connectors). The server implements Authorization Code + PKCE: when prompted, enter your Hub **client_id** and **client_secret**. The server exchanges these with Hub internally and returns a signed access token.
-- **Static bearer token** — for clients configured with a static `Authorization` header. Exchange your Hub credentials for a token first:
-
-  ```bash
-  curl -X POST https://auth.id.trade-tariff.service.gov.uk/oauth2/token \
-    -d "grant_type=client_credentials&client_id=<client_id>&client_secret=<client_secret>&scope=tariff/read"
-  ```
-
-  Use the returned `access_token` as your bearer token. Tokens expire — refresh them as needed.
+The server implements OAuth 2.0 Authorization Code + PKCE. When you connect a client, enter your Hub **client_id** and **client_secret** when prompted. The MCP server exchanges these with Hub internally and returns a signed access token to the client.
 
 Requests without a valid token receive `401 Unauthorized`.
 
@@ -69,22 +59,17 @@ Every tool accepts these optional parameters:
 
 ## Connecting AI clients
 
-The MCP server uses streamable HTTP transport. Configuration varies slightly between clients.
+The MCP server uses streamable HTTP transport and OAuth 2.0 Authorization Code + PKCE for authentication. Add the server URL and enter your Hub **client_id** and **client_secret** when your client prompts for credentials.
 
 ### Claude Desktop
 
-Claude Desktop supports OAuth discovery. When you add the server it will open a prompt asking for credentials — enter your Hub **client_id** and **client_secret**.
-
-Alternatively, exchange your credentials for a bearer token (see [Before you start](#before-you-start)) and supply it as a static header in `claude_desktop_config.json`:
+Add to `claude_desktop_config.json`:
 
 ```json
 {
   "mcpServers": {
     "trade-tariff": {
-      "url": "https://mcp.trade-tariff.service.gov.uk/mcp",
-      "headers": {
-        "Authorization": "Bearer YOUR_ACCESS_TOKEN"
-      }
+      "url": "https://mcp.trade-tariff.service.gov.uk/mcp"
     }
   }
 }
@@ -95,11 +80,11 @@ File locations:
 - **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
 - **Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
 
-Restart Claude Desktop after saving.
+Restart Claude Desktop after saving. It will prompt for credentials on first use.
 
 ### Cursor
 
-Add to your global config or a project-scoped `.cursor/mcp.json` in your project root. Global config locations:
+Add to your global config or a project-scoped `.cursor/mcp.json`:
 
 - **macOS / Linux**: `~/.cursor/mcp.json`
 - **Windows**: `%USERPROFILE%\.cursor\mcp.json`
@@ -108,20 +93,17 @@ Add to your global config or a project-scoped `.cursor/mcp.json` in your project
 {
   "mcpServers": {
     "trade-tariff": {
-      "url": "https://mcp.trade-tariff.service.gov.uk/mcp",
-      "headers": {
-        "Authorization": "Bearer YOUR_ACCESS_TOKEN"
-      }
+      "url": "https://mcp.trade-tariff.service.gov.uk/mcp"
     }
   }
 }
 ```
 
-Cursor picks up changes without a restart.
+Cursor picks up changes without a restart and will prompt for credentials on first use.
 
 ### Windsurf
 
-Add to your Windsurf MCP config. File locations:
+Add to your Windsurf MCP config:
 
 - **macOS / Linux**: `~/.codeium/windsurf/mcp_config.json`
 - **Windows**: `%USERPROFILE%\.codeium\windsurf\mcp_config.json`
@@ -130,10 +112,7 @@ Add to your Windsurf MCP config. File locations:
 {
   "mcpServers": {
     "trade-tariff": {
-      "url": "https://mcp.trade-tariff.service.gov.uk/mcp",
-      "headers": {
-        "Authorization": "Bearer YOUR_ACCESS_TOKEN"
-      }
+      "url": "https://mcp.trade-tariff.service.gov.uk/mcp"
     }
   }
 }
@@ -143,33 +122,20 @@ Restart Windsurf after saving.
 
 ### VS Code (GitHub Copilot)
 
-Add to `.vscode/mcp.json` in your workspace (works on all platforms), or to your user-level `mcp.json`:
+Add to `.vscode/mcp.json` in your workspace, or to your user-level `mcp.json`:
 
 - **macOS**: `~/Library/Application Support/Code/User/mcp.json`
 - **Windows**: `%APPDATA%\Code\User\mcp.json`
 - **Linux**: `~/.config/Code/User/mcp.json`
-
-The `${input:tradeTariffToken}` placeholder means VS Code will prompt you for the token rather than storing it in plain text:
 
 ```json
 {
   "servers": {
     "trade-tariff": {
       "type": "http",
-      "url": "https://mcp.trade-tariff.service.gov.uk/mcp",
-      "headers": {
-        "Authorization": "Bearer ${input:tradeTariffToken}"
-      }
+      "url": "https://mcp.trade-tariff.service.gov.uk/mcp"
     }
-  },
-  "inputs": [
-    {
-      "id": "tradeTariffToken",
-      "type": "promptString",
-      "description": "Trade Tariff API access token",
-      "password": true
-    }
-  ]
+  }
 }
 ```
 

--- a/source/mcp.html.md.erb
+++ b/source/mcp.html.md.erb
@@ -18,7 +18,7 @@ The MCP server requires credentials from the Trade Tariff developer hub. Here is
 2. Once signed in, create a new **Trade Tariff key** — give it any name that identifies your project
 3. Copy the **client_id** and **client_secret** shown after creation — you will need these when connecting your AI client
 
-When you add the MCP server to your AI client, it will open a browser window asking you to sign in and authorise access. Enter your **client_id** and **client_secret** when prompted. This happens once; the client then stores a token and reconnects automatically.
+You will need your **client_id** and **client_secret** when adding the server to your AI client. The exact flow varies by client — see the instructions below for your specific tool.
 
 Requests without a valid token receive `401 Unauthorized`.
 
@@ -71,8 +71,8 @@ The MCP server uses streamable HTTP transport and OAuth 2.0 Authorization Code +
 
 1. Open Claude Desktop and go to **Settings** → **Connectors** → **Customize**
 2. Click **Add custom connector**
-3. Enter the server URL: `https://mcp.trade-tariff.service.gov.uk/`
-4. Click **Add** — Claude Desktop will prompt for your Hub **client_id** and **client_secret**
+3. Enter the server URL `https://mcp.trade-tariff.service.gov.uk/` along with your Hub **client_id** and **client_secret**
+4. Click **Add**
 
 **Via config file:**
 

--- a/source/mcp.html.md.erb
+++ b/source/mcp.html.md.erb
@@ -12,9 +12,13 @@ The server implements [MCP 2025-11-25](https://modelcontextprotocol.io) using st
 
 ## Before you start
 
-Register at the <a href="https://hub.trade-tariff.service.gov.uk/" target="_blank" rel="noreferrer noopener">Trade Tariff developer portal (opens in new tab)</a> and create an application. You will receive a **client_id** and **client_secret**.
+The MCP server requires credentials from the Trade Tariff developer hub. Here is how to get them:
 
-The server implements OAuth 2.0 Authorization Code + PKCE. When you connect a client, enter your Hub **client_id** and **client_secret** when prompted.
+1. Go to the <a href="https://hub.trade-tariff.service.gov.uk/" target="_blank" rel="noreferrer noopener">Trade Tariff developer portal (opens in new tab)</a> and create a free account
+2. Once signed in, create a new **application** — give it any name that identifies your project
+3. Copy the **client_id** and **client_secret** shown after creation — you will need these when connecting your AI client
+
+When you add the MCP server to your AI client, it will open a browser window asking you to sign in and authorise access. Enter your **client_id** and **client_secret** when prompted. This happens once; the client then stores a token and reconnects automatically.
 
 Requests without a valid token receive `401 Unauthorized`.
 

--- a/source/mcp.html.md.erb
+++ b/source/mcp.html.md.erb
@@ -65,6 +65,20 @@ Every tool accepts these optional parameters:
 
 The MCP server uses streamable HTTP transport and OAuth 2.0 Authorization Code + PKCE for authentication. Add the server URL and enter your Dev Portal **client_id** and **client_secret** when your client prompts for credentials.
 
+Jump to your client:
+
+- [Claude Desktop](#claude-desktop)
+- [Cursor](#cursor)
+- [Windsurf](#windsurf)
+- [GitHub Copilot](#github-copilot)
+  - [Copilot Chat on github.com (no IDE required)](#copilot-chat-on-github-com-no-ide-required)
+  - [VS Code](#vs-code)
+  - [Visual Studio](#visual-studio)
+  - [JetBrains IDEs](#jetbrains-ides-intellij-rider-pycharm-etc)
+  - [Copilot CLI](#copilot-cli)
+- [Microsoft Copilot](#microsoft-copilot)
+- [ChatGPT](#chatgpt)
+
 ### Claude Desktop
 
 **Via settings UI:**

--- a/source/mcp.html.md.erb
+++ b/source/mcp.html.md.erb
@@ -15,7 +15,7 @@ The server implements [MCP 2025-11-25](https://modelcontextprotocol.io) using st
 The MCP server requires credentials from the Trade Tariff developer hub. Here is how to get them:
 
 1. Go to the <a href="https://hub.trade-tariff.service.gov.uk/" target="_blank" rel="noreferrer noopener">Trade Tariff developer portal (opens in new tab)</a> and create a free account
-2. Once signed in, create a new **application** — give it any name that identifies your project
+2. Once signed in, create a new **Trade Tariff key** — give it any name that identifies your project
 3. Copy the **client_id** and **client_secret** shown after creation — you will need these when connecting your AI client
 
 When you add the MCP server to your AI client, it will open a browser window asking you to sign in and authorise access. Enter your **client_id** and **client_secret** when prompted. This happens once; the client then stores a token and reconnects automatically.

--- a/source/mcp.html.md.erb
+++ b/source/mcp.html.md.erb
@@ -14,7 +14,7 @@ The server implements [MCP 2025-11-25](https://modelcontextprotocol.io) using st
 
 Register at the <a href="https://hub.trade-tariff.service.gov.uk/" target="_blank" rel="noreferrer noopener">Trade Tariff developer portal (opens in new tab)</a> and create an application. You will receive a **client_id** and **client_secret**.
 
-The server implements OAuth 2.0 Authorization Code + PKCE. When you connect a client, enter your Hub **client_id** and **client_secret** when prompted. The MCP server exchanges these with Hub internally and returns a signed access token to the client.
+The server implements OAuth 2.0 Authorization Code + PKCE. When you connect a client, enter your Hub **client_id** and **client_secret** when prompted.
 
 Requests without a valid token receive `401 Unauthorized`.
 
@@ -159,7 +159,3 @@ Once connected, you can ask your AI assistant questions such as:
 - *"Search the tariff for 'electric vehicles'."*
 
 The assistant will call the relevant tool and return structured tariff data in its response.
-
-## Source code
-
-The MCP server is open source: [trade-tariff/mcp](https://github.com/trade-tariff/mcp).


### PR DESCRIPTION
## Summary

- Adds a new `/mcp.html` page documenting the Trade Tariff MCP server — endpoint URL, available tools, optional parameters (`service` and `validity_date`), and step-by-step instructions for connecting from Claude Desktop, Cursor, Windsurf, and VS Code
- Each client section covers both the settings UI path and the config file path
- Adds an MCP Server link to the site header navigation
- Adds an MCP section to `llms.txt` so AI clients that discover the API via the `Link: describedby` header also discover the MCP endpoint

## Risk

Low-risk: additive documentation only, no behaviour changes.

## Test plan

- [ ] Build the Middleman site locally (`bundle exec middleman build`) and verify `/mcp.html` renders correctly
- [ ] Check the MCP Server link appears in the site header
- [ ] Verify `llms.txt` contains the new MCP section
- [ ] Check that UI and config instructions render correctly for all four clients