### PR TITLE
Upgrade devcontainer Ruby to 4.0.5

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
-# Use the latest Ruby 3.3 image
-FROM mcr.microsoft.com/devcontainers/ruby:3.3
+# Use the latest Ruby image
+FROM mcr.microsoft.com/devcontainers/ruby:latest
 
 # Set environment variables
 ENV NODE_VERSION=23
@@ -19,9 +19,9 @@ RUN curl -fsSL https://deb.nodesource.com/setup_${NODE_VERSION}.x | bash - && \
 # Fix Yarn conflict (if needed)
 RUN rm -f /usr/bin/yarnpkg /usr/bin/yarn
 
-# Install Ruby 4.0.1 using ruby-install
+# Install Ruby 4.0.5 using ruby-install
 RUN curl -fsSL https://github.com/postmodern/ruby-install/archive/v0.8.2.tar.gz | tar xz && \
     cd ruby-install-0.8.2 && \
     make install && \
-    ruby-install --system ruby 4.0.1 && \
+    ruby-install --system ruby 4.0.5 && \
     rm -rf ruby-install-0.8.2


### PR DESCRIPTION
### Jira link

No Jira ticket/issue.

### What?

- [x] Update the devcontainer base image to use the current Ruby devcontainer image.
- [x] Install Ruby 4.0.5 in the devcontainer with ruby-install.

### Why?

Ruby 4.0.5 is the current Ruby release and the devcontainer should match the global Ruby upgrade target.

### Risk

**Risk level:** 🟢

**Reason for rating:** Development container only; no production application runtime or API behaviour changes.

### Verification

- [x] `docker build -f .devcontainer/Dockerfile .`
