### PR TITLE
HMRC-2408 Add Debride pre-push hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,10 @@
 ---
+default_install_hook_types:
+  - pre-commit
+  - pre-push
+default_stages:
+  - pre-commit
+
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
@@ -22,3 +28,9 @@ repos:
     rev: v1.7.12
     hooks:
       - id: actionlint-docker
+
+  - repo: https://github.com/trade-tariff/trade-tariff-tools
+    rev: main
+    hooks:
+      - id: debride
+        args: [--no-rails, --, config.rb, bin, source, templates]

--- a/Gemfile
+++ b/Gemfile
@@ -21,3 +21,7 @@ gem 'rdoc'
 gem 'sprockets', '~> 4.0'
 
 gem 'rubocop-govuk'
+
+group :test do
+  gem 'debride', '~> 1.15', require: false
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,6 +51,10 @@ GEM
     contracts (0.17.3)
     csv (3.3.5)
     date (3.5.1)
+    debride (1.15.2)
+      path_expander (~> 2.0)
+      prism (~> 1.7)
+      sexp_processor (~> 4.17)
     dotenv (3.2.0)
     drb (2.2.3)
     em-websocket (0.5.3)
@@ -185,6 +189,7 @@ GEM
       ast (~> 2.4.1)
       racc
     parslet (2.0.0)
+    path_expander (2.0.1)
     prism (1.9.0)
     psych (5.4.0)
       date
@@ -260,6 +265,7 @@ GEM
     schmooze (0.2.0)
     securerandom (0.4.1)
     servolux (0.13.0)
+    sexp_processor (4.17.5)
     sprockets (4.2.2)
       concurrent-ruby (~> 1.0)
       logger
@@ -292,6 +298,7 @@ DEPENDENCIES
   brakeman
   builder
   cgi
+  debride (~> 1.15)
   govuk_tech_docs
   logger
   middleman-gh-pages
@@ -303,7 +310,7 @@ DEPENDENCIES
   sprockets (~> 4.0)
 
 RUBY VERSION
-   ruby 4.0.5p0
+  ruby 4.0.5p0
 
 BUNDLED WITH
-   2.6.7
+  4.0.10

--- a/config.rb
+++ b/config.rb
@@ -65,7 +65,4 @@ helpers do
     concat_content(svg.html_safe)
   end
 
-  def convert_markdown(markdown_content)
-    ::Kramdown::Document.new(markdown_content).to_html
-  end
 end

--- a/config/debride.whitelist
+++ b/config/debride.whitelist
@@ -1,0 +1,4 @@
+# Debride cannot see framework convention calls reliably.
+# This normalized baseline is compared by trade-tariff-tools/debride.
+
+main#graphviz

--- a/flake.lock
+++ b/flake.lock
@@ -138,7 +138,8 @@
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
         "nixpkgs-ruby": "nixpkgs-ruby",
-        "pre-commit-hooks": "pre-commit-hooks"
+        "pre-commit-hooks": "pre-commit-hooks",
+        "trade-tariff-tools": "trade-tariff-tools"
       }
     },
     "systems": {
@@ -153,6 +154,23 @@
       "original": {
         "owner": "nix-systems",
         "repo": "default",
+        "type": "github"
+      }
+    },
+    "trade-tariff-tools": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1782213097,
+        "narHash": "sha256-uQyF1hojMxmw1yY1ReMEebbKyAnjKSdG/Zkx5j3MDSs=",
+        "owner": "trade-tariff",
+        "repo": "trade-tariff-tools",
+        "rev": "1cf7af52c35d7a3425c424731320423f4fea1486",
+        "type": "github"
+      },
+      "original": {
+        "owner": "trade-tariff",
+        "ref": "main",
+        "repo": "trade-tariff-tools",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -11,6 +11,10 @@
       inputs.nixpkgs.follows = "nixpkgs";
       inputs.flake-utils.follows = "flake-utils";
     };
+    trade-tariff-tools = {
+      url = "github:trade-tariff/trade-tariff-tools/main";
+      flake = false;
+    };
   };
 
   outputs =
@@ -19,6 +23,7 @@
       flake-utils,
       pre-commit-hooks,
       nixpkgs-ruby,
+      trade-tariff-tools,
       ...
     }:
     flake-utils.lib.eachDefaultSystem (
@@ -96,6 +101,14 @@
             trufflehog = {
               enable = true;
               stages = [ "pre-commit" ];
+            };
+            debride = {
+              enable = true;
+              name = "debride";
+              description = "Run Debride before pushing";
+              entry = "${trade-tariff-tools}/.github/actions/debride/debride-check --no-rails -- config.rb bin source templates";
+              pass_filenames = false;
+              stages = [ "pre-push" ];
             };
 
             rubocop = {


### PR DESCRIPTION
## What:
Adds Debride as a Bundler-backed dead-code check and wires it into the pre-push hook stage for Nix and non-Nix pre-commit setups. Where this repo already runs pre-commit in CI, CI now explicitly runs both pre-commit and pre-push hook stages.

The hook implementation is consumed from the shared `trade-tariff-tools` Debride action/pre-commit hook introduced in trade-tariff/trade-tariff-tools#154.

## Why:
This keeps newly introduced unused Ruby methods visible before review and shares the implementation across Trade Tariff Ruby repos instead of copying hook logic.

## Ticket:
https://transformuk.atlassian.net/browse/HMRC-2408

## Risk:
**Risk level:** 🟢

**Reason for rating:**
Developer-tooling and CI validation only. This does not change runtime application behavior, deployed infrastructure, data processing, API behavior, or trader-facing content.

## Verification:
- `pre-commit validate-config .pre-commit-config.yaml`
- `pre-commit run -c .pre-commit-config.yaml --all-files --hook-stage pre-push debride`
- `nix develop -c pre-commit run --all-files --hook-stage pre-push debride`
- Commit hooks passed for this branch
- Push hook ran Debride successfully for this branch
