### PR TITLE
docs: update API docs accuracy  

### DIFF
--- a/source/categorisation-terms-and-conditions.html.md.erb
+++ b/source/categorisation-terms-and-conditions.html.md.erb
@@ -2,23 +2,53 @@
 
 # Terms and Conditions for Use of the Trade Categorisation Tool
 
-By using this service, you (the software developer) indicate that you accept these terms and conditions and agree to abide by them.
+By using this service, you (the software developer) indicate that you accept
+these terms and conditions and agree to abide by them.
 
-The service is owned and operated by the Online Trade Tariff Team within His Majesty's Revenue and Customs (HMRC).
+The service is owned and operated by the Online Trade Tariff Team within His
+Majesty's Revenue and Customs (HMRC).
 
 ## Conditions of Use
 
-The API is designated for backend operations only and should not be directly integrated into any customer-facing interfaces, applications, or websites.
+The API is designated for backend operations only and should not be directly
+integrated into any customer-facing interfaces, applications, or websites.
 
-Any access credentials are for the sole use of the UKIMS registered user to which they have been granted. They may be shared and used by third-party suppliers but must only be used for the purposes of providing services to the registered user. It is the responsibility of the registered user to ensure that their suppliers adhere to these terms and that access credentials are kept confidential.
+Any access credentials are for the sole use of the UKIMS registered user
+to which they have been granted. They may be shared and used by third-party
+suppliers but must only be used for the purposes of providing services to the
+registered user. It is the responsibility of the registered user to ensure
+that their suppliers adhere to these terms and that access credentials are kept
+confidential.
 
-The API is only intended for the categorisation of trades between the Great Britain and the Northern Ireland that are classified as "Not at Risk" of onward movement out of Northern Ireland, where Northern Ireland is their final destination and place of use/consumption.
+The API is only intended for the categorisation of trades between the Great
+Britain and the Northern Ireland that are classified as "Not at Risk" of
+onward movement out of Northern Ireland, where Northern Ireland is their final
+destination and place of use/consumption.
 
-The API is only available to UKIMS registered users. No access will be given without this authorisation — <a href="https://www.gov.uk/guidance/apply-for-authorisation-for-the-uk-internal-market-scheme-if-you-bring-goods-into-northern-ireland" target="_blank" rel="noreferrer noopener">apply for UKIMS here (opens in new tab)</a>.
+The API is only available to UKIMS registered users. No access will be given
+without this authorisation —
+<%= link_to "apply for UKIMS here (opens in new tab)",
+  "https://www.gov.uk/guidance/apply-for-authorisation-for-the-uk-internal-ma
+rket-scheme-if-you-bring-goods-into-northern-ireland",
+  class: "govuk-link",
+  target: "_blank",
+  rel: "noreferrer noopener"
+%>. To request access to the Categorisation API you will need to send us your
+UKIMS registration number, organisation name, and work email address by using
+our
+<%= link_to "enquiry form",
+  "https://www.trade-tariff.service.gov.uk/enquiry_form",
+  class: "govuk-link",
+  target: "_blank",
+  rel: "noreferrer noopener"
+%>.
 
-By using the API, you agree not to discuss or publicly disclose any details, functionalities, or details of the performance of the API without prior written consent from HMRC.
+By using the API, you agree not to discuss or publicly disclose any details,
+functionalities, or details of the performance of the API without prior written
+consent from HMRC.
 
-Usage of the API will be logged, and the data collected may be utilised to enhance the service.
+Usage of the API will be logged, and the data collected may be utilised to
+enhance the service.
 
 You may not conduct performance or security testing on the API.
 
@@ -26,50 +56,89 @@ You may not conduct performance or security testing on the API.
 
 We will:
 
-- Give you at least 6 months’ notice of major/breaking changes affecting any stable APIs.
+- Give you at least 6 months' notice of major/breaking changes affecting any
+  stable APIs.
 - Make sure any minor changes made to stable APIs are backwards compatible.
-- Provide reasonable notice of changes affecting beta APIs, which can change fairly frequently.
+- Provide reasonable notice of changes affecting beta APIs, which can change
+  fairly frequently.
 - Warn you before we retire an API.
 
 ## Accuracy of Data
 
-Although HMRC shall take all reasonable steps to ensure that the data provided is accurate and up to date before it is transmitted, no legal responsibility is accepted for any errors, omissions, or misleading statements.
+Although HMRC shall take all reasonable steps to ensure that the data provided
+is accurate and up to date before it is transmitted, no legal responsibility is
+accepted for any errors, omissions, or misleading statements.
 
 ## Audits and Reviews
 
-HMRC reserves the right to carry out audits and reviews of your compliance with the terms of this service, and you, the customer, shall agree to co-operate fully with any such audit or review.
+HMRC reserves the right to carry out audits and reviews of your compliance with
+the terms of this service, and you, the customer, shall agree to co-operate
+fully with any such audit or review.
 
 ## General Enquiries
 
-For general technical enquiries for this service, HMRC Trade Tariff Technical Support can be contacted between the hours of 09:00 and 17:00 Monday to Friday (excluding English bank holidays) by e-mailing [hmrc-trade-tariff-support-g@digital.hmrc.gov.uk](mailto:hmrc-trade-tariff-support-g@digital.hmrc.gov.uk).
+For general technical enquiries for this service, HMRC Trade Tariff
+Technical Support can be contacted between the hours of 09:00 and
+17:00 Monday to Friday (excluding English bank holidays) by using our
+<%= link_to "enquiry form",
+  "https://www.trade-tariff.service.gov.uk/enquiry_form",
+  class: "govuk-link",
+  target: "_blank",
+  rel: "noreferrer noopener"
+%>.
 
 ## Suspension and Termination
 
-Where HMRC considers the service to have been misused by the customer, it reserves the right to suspend the service offering immediately until appropriate evidence is supplied to allay concerns.
+Where HMRC considers the service to have been misused by the customer, it
+reserves the right to suspend the service offering immediately until appropriate
+evidence is supplied to allay concerns.
 
-HMRC reserves the right to withdraw the service at any point and will provide you with 7 working days' notice.
+HMRC reserves the right to withdraw the service at any point and will provide
+you with 7 working days' notice.
 
 ## Disabling and Deactivation
 
-Should your API account remain unused for a period of 90 days, this may result in the disablement of your API key. If we do not receive contact from you within 120 days from the start of the unused period, your API account may be deleted.
+Should your API account remain unused for a period of 90 days, this may result
+in the disablement of your API key. If we do not receive contact from you within
+120 days from the start of the unused period, your API account may be deleted.
 
 ## Continuity of Service
 
-Where possible, HMRC will use reasonable endeavours to ensure that there is no break in the continuity of service and will only make changes when required.
+Where possible, HMRC will use reasonable endeavours to ensure that there is no
+break in the continuity of service and will only make changes when required.
 
-Outages may be required on occasions where essential upgrades to the service need to be implemented.
+Outages may be required on occasions where essential upgrades to the service
+need to be implemented.
 
-HMRC will endeavour when possible to contact you with advance notice of any planned outages or maintenance. We will use the contact details you provided, therefore it is important that these are kept up to date by you. Should contact details change, you must inform the HMRC Trade Tariff Technical Support using the general contact details above.
+HMRC will endeavour when possible to contact you with advance notice of any
+planned outages or maintenance. We will use the contact details you provided,
+therefore it is important that these are kept up to date by you. Should contact
+details change, you must inform the HMRC Trade Tariff Technical Support using
+the general contact details above.
 
-HMRC will limit the rate of requests made to the API service to ensure full functionality is maintained. We reserve the right to monitor usage of the service and to amend rate plans where necessary.
+HMRC will limit the rate of requests made to the API service to ensure full
+functionality is maintained. We reserve the right to monitor usage of the
+service and to amend rate plans where necessary.
 
 ## Service Incidents
 
-For issues with the service, the HMRC Trade Tariff Technical Support team can be contacted between the hours of 09:00 and 17:00 Monday to Friday (excluding English bank holidays) by e-mailing [hmrc-trade-tariff-support-g@digital.hmrc.gov.uk](mailto:hmrc-trade-tariff-support-g@digital.hmrc.gov.uk).
+For issues with the service, the HMRC Trade Tariff Technical
+Support team can be contacted between the hours of 09:00 and 17:00
+Monday to Friday (excluding English bank holidays) by using our
+<%= link_to "enquiry form",
+  "https://www.trade-tariff.service.gov.uk/enquiry_form",
+  class: "govuk-link",
+  target: "_blank",
+  rel: "noreferrer noopener"
+%>.
 
 ## Disclaimer
 
-HMRC does not accept liability for loss or damage incurred by users of this service, whether direct, indirect, or consequential, whether caused by tort, breach of contract, or otherwise, in connection with our service, its use, the inability to use, or results of the use of our service, any websites linked to it, and any materials posted on it.
+HMRC does not accept liability for loss or damage incurred by users of this
+service, whether direct, indirect, or consequential, whether caused by tort,
+breach of contract, or otherwise, in connection with our service, its use, the
+inability to use, or results of the use of our service, any websites linked to
+it, and any materials posted on it.
 
 This includes loss of:
 
@@ -84,34 +153,62 @@ This includes loss of:
 
 ## Virus Protection
 
-HMRC will make every effort to check and test material at all stages of production. However, you must take your own precautions to ensure that the process you employ for accessing this service does not expose you to the risk of viruses, malicious computer code, or other forms of interference which may damage your own computer system.
+HMRC will make every effort to check and test material at all stages of
+production. However, you must take your own precautions to ensure that the
+process you employ for accessing this service does not expose you to the risk
+of viruses, malicious computer code, or other forms of interference which may
+damage your own computer system.
 
-HMRC does not accept responsibility for any loss, disruption, or damage to your data or your computer system which may occur whilst using material derived from this service.
+HMRC does not accept responsibility for any loss, disruption, or damage to your
+data or your computer system which may occur whilst using material derived from
+this service.
 
 ## Viruses, Hacking, and Other Offences
 
-You, the customer, will not misuse the service by knowingly introducing viruses, trojans, worms, logic bombs, or other material which is malicious or technologically harmful. You will not attempt to gain unauthorised access to the service or any server, computer, or database connected to HMRC. You will not attack our service via a denial-of-service attack or a distributed denial-of-service attack.
+You, the customer, will not misuse the service by knowingly introducing
+viruses, trojans, worms, logic bombs, or other material which is malicious
+or technologically harmful. You will not attempt to gain unauthorised access
+to the service or any server, computer, or database connected to HMRC. You
+will not attack our service via a denial-of-service attack or a distributed
+denial-of-service attack.
 
-By breaching this provision, you would commit a criminal offence under the Computer Misuse Act 1990. We will report any such breach to the relevant law enforcement authorities, and we will co-operate with those authorities by disclosing your identity to them.
+By breaching this provision, you would commit a criminal offence under the
+Computer Misuse Act 1990. We will report any such breach to the relevant law
+enforcement authorities, and we will co-operate with those authorities by
+disclosing your identity to them.
 
 ## Use of HMRC's Logo
 
-The names, images, and logos identifying HMRC are proprietary marks of HMRC. The use or copying of our logos and/or any other third-party logos is not permitted without prior approval from the relevant copyright owner.
+The names, images, and logos identifying HMRC are proprietary marks of HMRC. The
+use or copying of our logos and/or any other third-party logos is not permitted
+without prior approval from the relevant copyright owner.
 
 ## Changes
 
-HMRC reserves the right, at its discretion, to make changes to any part of this service, the information, or these terms. Should HMRC change these terms and conditions, the customer will be notified by email using the contact details provided at registration.
+HMRC reserves the right, at its discretion, to make changes to any part of this
+service, the information, or these terms. Should HMRC change these terms and
+conditions, the customer will be notified by email using the contact details
+provided at registration.
 
 ## Severability
 
-If any of these terms and conditions are held to be invalid, unenforceable, or illegal for any reason, the remaining terms and conditions shall nevertheless continue in full force.
+If any of these terms and conditions are held to be invalid, unenforceable, or
+illegal for any reason, the remaining terms and conditions shall nevertheless
+continue in full force.
 
-If HMRC waives any rights available to it under these terms and conditions on one occasion, this does not mean that those rights will automatically be waived on any other occasion.
+If HMRC waives any rights available to it under these terms and conditions on
+one occasion, this does not mean that those rights will automatically be waived
+on any other occasion.
 
 ## Events Beyond HMRC Control
 
-HMRC accepts no liability for any failure to comply with these terms and conditions where such failure is due to circumstances beyond our reasonable control.
+HMRC accepts no liability for any failure to comply with these terms and
+conditions where such failure is due to circumstances beyond our reasonable
+control.
 
 ## Governing Law
 
-These terms and conditions shall be governed by and construed in accordance with the laws of England and Wales. Any dispute arising under these terms and conditions shall be subject to the exclusive jurisdiction of the courts of England and Wales.
+These terms and conditions shall be governed by and construed in accordance
+with the laws of England and Wales. Any dispute arising under these terms and
+conditions shall be subject to the exclusive jurisdiction of the courts of
+England and Wales.

--- a/source/categorisation-terms-and-conditions.html.md.erb
+++ b/source/categorisation-terms-and-conditions.html.md.erb
@@ -39,7 +39,6 @@ our
 <%= link_to "enquiry form",
   "https://www.trade-tariff.service.gov.uk/enquiry_form",
   class: "govuk-link",
-  target: "_blank",
   rel: "noreferrer noopener"
 %>.
 
@@ -83,7 +82,6 @@ Technical Support can be contacted between the hours of 09:00 and
 <%= link_to "enquiry form",
   "https://www.trade-tariff.service.gov.uk/enquiry_form",
   class: "govuk-link",
-  target: "_blank",
   rel: "noreferrer noopener"
 %>.
 
@@ -128,7 +126,6 @@ Monday to Friday (excluding English bank holidays) by using our
 <%= link_to "enquiry form",
   "https://www.trade-tariff.service.gov.uk/enquiry_form",
   class: "govuk-link",
-  target: "_blank",
   rel: "noreferrer noopener"
 %>.
 

--- a/source/categorisation.html.md.erb
+++ b/source/categorisation.html.md.erb
@@ -14,9 +14,11 @@ highlight_theme: darkula
   <link href="/green_lanes.xml" type="application/atom+xml" rel="alternate" title="Windsor Framework Categorisation API changes feed" />
 <% end %>
 
-The Windsor Framework Categorisation API's provide access to the trade tariff data for trade with Northern Ireland.
+The Windsor Framework Categorisation API's provide access to the trade tariff
+data for trade with Northern Ireland.
 
-These APIs follow the JSON-API format for both request and response, in common with the other OTT APIs documented on this site.
+These APIs follow the JSON-API format for both request and response, in common
+with the other OTT APIs documented on this site.
 
 ## Base URL
 
@@ -26,12 +28,12 @@ All requests to this API should be prefixed with the following URL:
 
 ## Authentication
 
-
 API Key: Parameter **X-Api-Key**, in header.
+Access to these APIs will be restricted. Approved partners requiring access
+should contact the Online Trade Tariff team.
 
-Access to these APIs will be restricted. Approved partners requiring access should contact the Online Trade Tariff team.
-
-Those eligible traders will be supplied with a secret API key which should be included in the `X-Api-Key` header of every request, e.g.:
+Those eligible traders will be supplied with a secret API key which should be
+included in the `X-Api-Key` header of every request, e.g.:
 
 ```
 X-Api-Key: a1b2c3defg4567
@@ -39,7 +41,8 @@ X-Api-Key: a1b2c3defg4567
 
 **Sample client**
 
-There's a very simple HTML page client as an example of parsing these APIs in JavaScript.
+There's a very simple HTML page client as an example of parsing these APIs in
+JavaScript.
 
 [View sample client](/categorisation-sample-client.html) &nbsp; | &nbsp;
 <a download="categorisation-sample-client.html" href="/categorisation-sample-client.html">
@@ -2084,3 +2087,8 @@ Listing of all category assessments
 Name|Type|Required|Description
 ---|---|---|---|
 data|[[CategoryAssessment](#schemacategoryassessment)]|false|An individual CategoryAssessment
+
+## Terms and conditions
+
+By using this API you agree to the [Terms and Conditions for Use of the Trade
+Categorisation Tool](/categorisation-terms-and-conditions.html).

--- a/source/developer-portal.html.md.erb
+++ b/source/developer-portal.html.md.erb
@@ -12,20 +12,39 @@ The Developer Portal allows you to:
 - manage organisational details
 - invite new members and remove existing members
 
-At present, API key management is available for the Trade Tariff API and FPO API. Categorisation API keys will be added in a future phase.
+At present, API key management is available for the Trade Tariff API. Other APIs
+may become available in the future.
 
-<a href="https://hub.trade-tariff.service.gov.uk/" role="button" draggable="false" class="govuk-button" data-module="govuk-button" target="_blank" rel="noreferrer noopener">
+<a
+  href="https://hub.trade-tariff.service.gov.uk/"
+  role="button"
+  draggable="false"
+  class="govuk-button"
+  data-module="govuk-button" target="_blank" rel="noreferrer noopener">
   Sign up to the Trade Tariff API developer portal (opens in new tab)
 </a>
 
 ## Why sign up to the Developer Portal?
 
-From September 2026, rate limiting will apply to the Trade Tariff API. Rate limiting sets a cap on the number of requests you can make per minute.
+From September 2026, rate limiting will apply to the Trade Tariff API. Rate
+limiting sets a cap on the number of requests you can make per minute.
 
-You need developer portal credentials to call the Trade Tariff API on <code>api.trade-tariff.service.gov.uk</code>. By registering on the Developer Portal, you can create API keys and access a rate limit of 750 requests per minute.
+You need developer portal credentials to call the Trade Tariff API on
+<code>api.trade-tariff.service.gov.uk</code>. By registering on the Developer
+Portal, you can create API keys and access a rate limit of 750 requests per
+minute.
 
 <div class="govuk-inset-text">
-  <strong>Managed service host change:</strong> Trade Tariff keys issued through the Developer Portal are used against <code>api.trade-tariff.service.gov.uk</code>, which requires OAuth 2.0 authentication. If you are migrating from <code>www.trade-tariff.service.gov.uk</code>, update the base URL in your integration and authenticate as described in <a class="govuk-link" href="/the-trade-tariff-api.html#authenticating-with-managed-credentials">Authenticating with managed credentials</a>.
+  <strong>Managed service host change:</strong>
+  Trade Tariff keys issued through the Developer Portal are used
+  against <code>api.trade-tariff.service.gov.uk</code>, which
+  requires OAuth 2.0 authentication. If you are migrating from
+  <code>www.trade-tariff.service.gov.uk</code>, update the base URL in your
+  integration and authenticate as described in
+  <%= link_to "Authenticating with managed credentials",
+    "/the-trade-tariff-api.html#authenticating-with-managed-credentials",
+     class: "govuk-link"
+  %>.
 </div>
 
 ## Who can use the Developer Portal?
@@ -36,17 +55,28 @@ Anyone who needs access to UK Trade Tariff data, including:
 - product managers overseeing compliance systems
 - trade and customs specialists seeking accurate, up-to-date information
 
-Whether you are a large enterprise or an independent trader, the APIs provide consistent and authoritative data from HMRC's Online Trade Tariff.
+Whether you are a large enterprise or an independent trader, the APIs provide
+consistent and authoritative data from HMRC's Online Trade Tariff.
 
 ## How can I register on the Developer Portal?
 
-Signing up to the Trade Tariff developer portal and accessing a higher rate limit could not be easier.
+Signing up to the Trade Tariff developer portal and accessing a higher rate
+limit could not be easier.
 
-You will need to verify your email address using a secure one-time link, as the Developer Portal uses passwordless sign-in.
+You will need to verify your email address using a secure time-based
+one-time password in the form of a 6-digit code, as the Developer Portal uses
+passwordless sign-in.
 
-Once verified, you will be able to create and manage API keys, update organisational details and invite others from your organisation.
+Once verified, you will be able to create and manage API keys, update
+organisational details and invite others from your organisation.
 
 
 ## Get help from HMRC
 
-If you have any questions or require help, please use the <a href="https://www.trade-tariff.service.gov.uk/enquiry_form" target="_blank" rel="noreferrer noopener">Trade Tariff enquiry form (opens in new tab)</a>.
+If you have any questions or require help, please use the
+<%= link_to "Trade Tariff enquiry form (opens in new tab)",
+  "https://www.trade-tariff.service.gov.uk/enquiry_form",
+  class: "govuk-link",
+  target: "_blank",
+  rel: "noreferrer noopener"
+%>.

--- a/source/fpo.html.md.erb
+++ b/source/fpo.html.md.erb
@@ -10,25 +10,44 @@ highlight_theme: darkula
 
 # FPO APIs
 
-The FPO (Fast Parcel Operator) Commodity Code Identification Tool API is a free-to-use API available to UK Carrier scheme (UKC) registered organisations.
+The FPO (Fast Parcel Operator) Commodity Code Identification Tool API is a
+free-to-use API available to UK Carrier scheme (UKC) registered organisations.
 
-For goods being moved from Great Britain to Northern Ireland it can help you identify:
+For goods being moved from Great Britain to Northern Ireland it can help you
+identify:
 
 - 6 digit HS (Harmonized system) codes
 
 - 8 digit CN (Combined nomenclature) codes
 
-The API accepts English language goods item descriptions and responds with a list of potential commodity codes for the item.
+The API accepts English language goods item descriptions and responds with a
+list of potential commodity codes for the item.
 
-For more information see the <a href="https://www.gov.uk/government/publications/moving-parcels-from-great-britain-to-northern-ireland-under-the-windsor-framework-from-30-september-2024" target="_blank" rel="noreferrer noopener">guidance for moving parcels from Great Britain to Northern Ireland under the Windsor Framework from 30 September 2024 (opens in new tab)</a>
+For more information see the
+<%= link_to "guidance for moving parcels from Great Britain to Northern Ireland under the Windsor Framework from 30 September 2024 (opens in new tab)",
+  "https://www.gov.uk/government/publications/moving-parcels-from-great-britain-to-northern-ireland-under-the-windsor-framework-from-30-september-2024",
+  class: "govuk-link",
+  target: "_blank",
+  rel: "noreferrer noopener"
+%>
 
-This API accepts HTTP requests and responds with <a href="https://en.wikipedia.org/wiki/JSON" target="_blank" rel="noreferrer noopener">JSON (opens in new tab)</a> data.
+This API accepts HTTP requests and responds with
+<%= link_to "JSON (opens in new tab)",
+  "https://en.wikipedia.org/wiki/JSON",
+  class: "govuk-link",
+  target: "_blank",
+  rel: "noreferrer noopener"
+%> data.
 
 ## Bulk processing
 
-Due to the synchronous operation of the API, if you're dealing with large volumes of data or are batch processing it's recommended to use a multi-threading, multi-processing or asynchronous approach to process several connections simultaneously.
+Due to the synchronous operation of the API, if you're dealing with
+large volumes of data or are batch processing it's recommended to use a
+multi-threading, multi-processing or asynchronous approach to process several
+connections simultaneously.
 
-This will be subject to rate limiting (to be implemented before 30 September 2024) which will allow up to 100 requests per second for each FPO.
+This will be subject to rate limiting (to be implemented before 30 September
+2024) which will allow up to 100 requests per second for each FPO.
 
 ## Base URL
 
@@ -36,30 +55,29 @@ All requests to this API should be prefixed with the following URL:
 
 **https://search.trade-tariff.service.gov.uk**
 
-
-
-
 ## Authentication
-
 
 API Key: Parameter **X-Api-Key**, in header.
 
-Access to these APIs is restricted to only those Fast Parcel Operators (FPOs) who have been invited to test the service.
+Access to these APIs is restricted to only those Fast Parcel Operators (FPOs)
+who have been invited to test the service.
 
-Those eligible organisations will be supplied with a secret API key which should be included in the `X-Api-Key` header of every request, e.g.:
+Those eligible organisations will be supplied with a secret API key which should
+be included in the `X-Api-Key` header of every request, e.g.:
 
 ```
 X-Api-Key: a1b2c3defg4567
 ```
 
-
 ## FPO endpoints
 
 ***POST /fpo-code-search***
 
-Carries out a search for potential commodity codes for a single line item within a parcel
+Carries out a search for potential commodity codes for a single line item within
+a parcel.
 
-To perform this operation, you must be authenticated by means of one of the following methods:
+To perform this operation, you must be authenticated by means of one of the
+following methods:
 
 apiKey
 
@@ -222,15 +240,30 @@ Name|Type|Required|Description
 message|string|true|The error message summary
 detail|string|false|Extra information about the error
 
-
 ## Support
 
-If you experience any issues or have questions regarding this API please contact [hmrc-trade-tariff-support-g@digital.hmrc.gov.uk](mailto:hmrc-trade-tariff-support-g@digital.hmrc.gov.uk)
+If you experience any issues or have questions regarding this API please contact
+the HMRC Trade Tariff Technical Support Team by using our
+<%= link_to "enquiry form",
+  "https://www.trade-tariff.service.gov.uk/enquiry_form",
+  class: "govuk-link",
+  target: "_blank",
+  rel: "noreferrer noopener"
+%>.
 
 ## Feedback
 
-We are continually updating the tool to improve the accuracy of the results produced. If you notice any incorrectly identified commodity codes, you can let us know through our <a href="https://forms.gle/F3NMxoLCkHNPc2MXA" target="_blank" rel="noreferrer noopener">inaccurate code feedback form (opens in new tab)</a>.
+We are continually updating the tool to improve the accuracy of the results
+produced. If you notice any incorrectly identified commodity codes, you can let
+us know through our
+<%= link_to "enquiry form",
+  "https://www.trade-tariff.service.gov.uk/enquiry_form",
+  class: "govuk-link",
+  target: "_blank",
+  rel: "noreferrer noopener"
+%>.
 
 ## Terms and Conditions
 
-By using this API you agree to the [Terms and Conditions for use of the FPO Commodity Code Identification Tool](/fpo/terms-and-conditions.html)
+By using this API you agree to the [Terms and Conditions for use of the FPO
+Commodity Code Identification Tool](/fpo/terms-and-conditions.html)

--- a/source/fpo.html.md.erb
+++ b/source/fpo.html.md.erb
@@ -247,7 +247,6 @@ the HMRC Trade Tariff Technical Support Team by using our
 <%= link_to "enquiry form",
   "https://www.trade-tariff.service.gov.uk/enquiry_form",
   class: "govuk-link",
-  target: "_blank",
   rel: "noreferrer noopener"
 %>.
 
@@ -259,7 +258,6 @@ us know through our
 <%= link_to "enquiry form",
   "https://www.trade-tariff.service.gov.uk/enquiry_form",
   class: "govuk-link",
-  target: "_blank",
   rel: "noreferrer noopener"
 %>.
 


### PR DESCRIPTION
## What:

### Developer portal page

- Remove direct mention of the FPO/Categorisation APIs
- Update registration section to reflect OTP code change

### FPO API page

- Replace support email with link to enquiry form

### Categorisation page

- Add link to Terms and Conditions page (sidebar link added automatically)

### Categorisation Terms and Conditions page

- Specify how to request access to the Categorisation API
- Replace support email with link to enquiry form

### Everything else

- Convert inline HTML anchor tags to embedded Ruby where appropriate.
- Reflow Markdown to 80-character lines for easier editing
  - **NOTE**: this does not change the output of the built HTML. See [development](https://docs.dev.trade-tariff.service.gov.uk/) to compare to production docs.


## Why:

- The Developer portal page mentions the FPO API without referring to the strict requirements and application process, and mentions the use of a secure one-time link as part of login.
- The Categorisation API page does not link to the Terms and Conditions.
- The Categorisation Terms and Conditions page does not specify how a user should request access to the FPO API, and contains incorrect guidance on how to send a support request.
- The FPO API page contains incorrect guidance on how to send a support request.

## Ticket:
[HMRC-2620](https://transformuk.atlassian.net/browse/HMRC-2620)
[HMRC-2637](https://transformuk.atlassian.net/browse/HMRC-2637)
[HMRC-2638](https://transformuk.atlassian.net/browse/HMRC-2638)
[HMRC-2639](https://transformuk.atlassian.net/browse/HMRC-2639)