### PR TITLE
feat(dev): support extensionless URLs in development server

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,4 +19,5 @@ gem 'ostruct'
 gem 'rdoc'
 gem 'sprockets', '~> 4.0'
 
+gem 'optional_html', git: 'https://github.com/tommysundstrom/middleman-rack-optional-html.git'
 gem 'rubocop-govuk'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,9 @@
+GIT
+  remote: https://github.com/tommysundstrom/middleman-rack-optional-html.git
+  revision: df1e50beca7599f3e47c5b83887573434f3253e3
+  specs:
+    optional_html (0.0.1)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -294,6 +300,7 @@ DEPENDENCIES
   logger
   mutex_m
   openapi3_parser
+  optional_html!
   ostruct
   rdoc
   rubocop-govuk

--- a/config.rb
+++ b/config.rb
@@ -2,6 +2,10 @@
 
 require 'govuk_tech_docs'
 require 'kramdown'
+require 'rack/middleman/optional_html'
+require 'nokogiri'
+
+use ::Rack::OptionalHtml, {}
 
 GovukTechDocs.configure(self)
 
@@ -24,17 +28,16 @@ ready do
        content = content.sub(/\A---\n.*?\n---\n/m, '')
        content = content.gsub(/<%.*?%>\n?/m, '')
        content = strip_html(content)
-       content = content.gsub(/\n{3,}/, "\n\n").strip + "\n"
+       content = "#{content.gsub(/\n{3,}/, "\n\n").strip}\n"
 
        relative = source_file.delete_prefix("#{source_root}/")
-       md_path = '/' + relative.sub(/\.html\.md(\.erb)?$/, '.md')
+       md_path = "/#{relative.sub(/\.html\.md(\.erb)?$/, '.md')}"
 
        proxy md_path, '/templates/raw_markdown_page.txt', locals: { markdown_content: content }, layout: false
      end
 end
 
 def strip_html(content)
-  require 'nokogiri'
   # <a href="...">text</a> → [text](href) — done before Nokogiri strips attributes
   content = content.gsub(%r{<a\s[^>]*href="([^"]*)"[^>]*>(.*?)</a>}m) do
     href = Regexp.last_match(1)


### PR DESCRIPTION
## What:
- Adds `optional_html` gem.
- Run `rubocop -A` and commit changes.

## Why:
- Allows extensionless URLs in the development server.

## Ticket:
N/A
